### PR TITLE
Theoretically prevent saving a clip when not recording

### DIFF
--- a/drivecam/lib/widgets/camera_view.dart
+++ b/drivecam/lib/widgets/camera_view.dart
@@ -209,7 +209,9 @@ class _CameraViewState extends State<CameraView> {
             children: [
               InkWell(
                 onTap: () {
-                  _triggerClipSave();
+                  if (context.read<RecordingProvider>().isRecording) {
+                    _triggerClipSave();
+                  }
                 },
                 child: SizedBox.expand(
                   child: FittedBox(


### PR DESCRIPTION
I don't have an Android device to test things on right now so I haven't tested if this works.

Closes #37 