### PR TITLE
Add recording size limits

### DIFF
--- a/drivecam/lib/main.dart
+++ b/drivecam/lib/main.dart
@@ -18,7 +18,9 @@ void main() async {
     DatabaseHelper().database, // init the db
   ]);
 
-  final recordingProvider = RecordingProvider();
+  // RecordingProvider needs SettingsProvider to read footage time and storage
+  // limits during rolling-buffer eviction without going through the widget tree.
+  final recordingProvider = RecordingProvider(settingsProvider);
   final clipProvider = ClipProvider(recordingProvider);
   recordingProvider.onRecordingSaved = clipProvider.processPendingClip;
 

--- a/drivecam/lib/main.dart
+++ b/drivecam/lib/main.dart
@@ -21,7 +21,9 @@ void main() async {
   // RecordingProvider needs SettingsProvider to read footage time and storage
   // limits during rolling-buffer eviction without going through the widget tree.
   final recordingProvider = RecordingProvider(settingsProvider);
-  final clipProvider = ClipProvider(recordingProvider);
+  // SettingsProvider is passed so ClipProvider can read clipStorageLimit
+  // during post-save eviction without going through the widget tree.
+  final clipProvider = ClipProvider(recordingProvider, settingsProvider);
   recordingProvider.onRecordingSaved = clipProvider.processPendingClip;
 
   runApp(

--- a/drivecam/lib/provider/clip_provider.dart
+++ b/drivecam/lib/provider/clip_provider.dart
@@ -9,11 +9,21 @@ import 'package:uuid/uuid.dart';
 import '../models/clip.dart';
 import '../models/recording.dart';
 import 'recording_provider.dart';
+import 'settings_provider.dart';
 
+/// Owns clip saving logic, clip notification state, and clip storage enforcement.
+///
+/// After each clip is saved the provider checks whether the total size of all
+/// stored clips exceeds [SettingsProvider.clipStorageLimit]. If so it deletes
+/// the oldest clip(s) — FIFO, by [date_time] ascending — until the total is
+/// back within the limit. This mirrors how [RecordingProvider] evicts old
+/// recording segments.
 class ClipProvider extends ChangeNotifier {
   final RecordingProvider _recordingProvider;
+  final SettingsProvider _settingsProvider;
 
-  ClipProvider(this._recordingProvider);
+  // [_settingsProvider] is needed to read clipStorageLimit during eviction.
+  ClipProvider(this._recordingProvider, this._settingsProvider);
 
   bool clipSaved = false;
   bool clipInProgress = false;
@@ -43,6 +53,43 @@ class ClipProvider extends ChangeNotifier {
   void _clearClipProgress() {
     clipInProgress = false;
     clipProgressEndTime = null;
+  }
+
+  /// Enforces the clip storage limit by deleting the oldest clips first.
+  ///
+  /// Loads all clips from the database, sums their sizes, then removes the
+  /// oldest clip (lowest [date_time]) repeatedly until the total is within
+  /// [SettingsProvider.clipStorageLimit]. Both the video file and its thumbnail
+  /// are deleted from disk before the DB row is removed.
+  ///
+  /// This is intentionally called *after* [insertClipDB] so the newly saved
+  /// clip is included in the total — if it alone would exceed the limit the
+  /// enforcement still fires and evicts the oldest entry, which may be the
+  /// clip that was just saved if no other clips exist.
+  ///
+  /// Exposed without a leading underscore so that unit tests can call it
+  /// directly after seeding the database. Do not call this from production
+  /// code outside of the two save methods below.
+  @visibleForTesting
+  Future<void> enforceClipStorageLimit() async {
+    final limitBytes = SettingsProvider.clipStorageLimitToBytes(
+        _settingsProvider.clipStorageLimit);
+
+    // loadAllClips returns clips ordered date_time DESC (newest first),
+    // so the oldest clip is always at the tail of the list.
+    final clips = await Clip.loadAllClips();
+    var totalBytes = clips.fold<int>(0, (sum, c) => sum + c.clipSize);
+    int fromEnd = clips.length - 1;
+
+    while (totalBytes > limitBytes && fromEnd >= 0) {
+      final oldest = clips[fromEnd];
+      // Delete files from disk; ignore errors if files are already missing.
+      try { await File(oldest.clipLocation).delete(); } catch (_) {}
+      try { await File(oldest.thumbnailLocation).delete(); } catch (_) {}
+      await oldest.deleteClipDB();
+      totalBytes -= oldest.clipSize;
+      fromEnd--;
+    }
   }
 
   /// Saves a clip of the last N seconds of the active recording.
@@ -169,6 +216,9 @@ class ClipProvider extends ChangeNotifier {
       clipLocation: clipPath,
       thumbnailLocation: thumbnailPath,
     ).insertClipDB();
+
+    // Remove oldest clip(s) if the total clip storage now exceeds the limit.
+    await enforceClipStorageLimit();
     _clearClipProgress();
     clipSaved = true;
   }
@@ -217,6 +267,9 @@ class ClipProvider extends ChangeNotifier {
       clipLocation: clipPath,
       thumbnailLocation: thumbnailPath,
     ).insertClipDB();
+
+    // Remove oldest clip(s) if the total clip storage now exceeds the limit.
+    await enforceClipStorageLimit();
     _clearClipProgress();
     clipSaved = true;
   }

--- a/drivecam/lib/provider/clip_provider.dart
+++ b/drivecam/lib/provider/clip_provider.dart
@@ -148,8 +148,10 @@ class ClipProvider extends ChangeNotifier {
     );
 
     // Keep xFile around — it is added to segments so it can be concatenated
-    // into the full session recording when recording stops.
-    _recordingProvider.addSegment(xFile.path);
+    // into the full session recording when recording stops. Pass elapsed so
+    // rolling-buffer eviction in RecordingProvider can correctly account for
+    // this segment's duration and estimated storage.
+    _recordingProvider.addSegment(xFile.path, elapsed);
 
     if (!await File(clipPath).exists()) return;
 

--- a/drivecam/lib/provider/recording_provider.dart
+++ b/drivecam/lib/provider/recording_provider.dart
@@ -289,6 +289,24 @@ class RecordingProvider extends ChangeNotifier {
     await onRecordingSaved?.call();
   }
 
+  /// Returns the number of completed segments currently tracked in the buffer.
+  ///
+  /// Only used by unit tests — do not read this from production code.
+  @visibleForTesting
+  int get segmentCount => _segmentInfos.length;
+
+  /// Returns the accumulated duration in seconds across all tracked segments.
+  ///
+  /// Only used by unit tests — do not read this from production code.
+  @visibleForTesting
+  int get totalSegmentDurationSeconds => _totalSegmentDurationSeconds;
+
+  /// Returns the accumulated estimated byte count across all tracked segments.
+  ///
+  /// Only used by unit tests — do not read this from production code.
+  @visibleForTesting
+  int get totalSegmentEstimatedBytes => _totalSegmentEstimatedBytes;
+
   /// Concatenates multiple video segments into a single output file using the
   /// FFmpeg concat demuxer. Segments must be from the same codec/format.
   Future<void> _concatenateSegments(

--- a/drivecam/lib/provider/recording_provider.dart
+++ b/drivecam/lib/provider/recording_provider.dart
@@ -1,3 +1,17 @@
+// recording_provider.dart
+// Manages the full lifecycle of a recording session: start/stop, segment
+// tracking, rolling-buffer eviction, and final file assembly via FFmpeg.
+//
+// Rolling-buffer design:
+//   Recording is split into segments when clips are saved, settings change,
+//   or the periodic 5-minute flush timer fires. Each completed segment carries
+//   a duration (seconds) and an estimated byte count (bitrate × duration ÷ 8).
+//   After every addSegment call, _evictOldestIfNeeded drops the oldest
+//   segment(s) from disk and the tracking list until both the time limit and
+//   the storage limit from SettingsProvider are satisfied. The final saved
+//   recording only contains the segments that survived eviction.
+
+import 'dart:async';
 import 'dart:io';
 
 import 'package:camera/camera.dart';
@@ -7,22 +21,59 @@ import 'package:path_provider/path_provider.dart';
 import 'package:uuid/uuid.dart';
 
 import '../models/recording.dart';
+import 'settings_provider.dart';
+
+// Holds metadata for one completed video segment so the rolling-buffer
+// eviction logic can account for duration and estimated storage without
+// additional disk I/O.
+class _SegmentInfo {
+  final String path;
+  final int durationSeconds;
+  final int estimatedBytes;
+  const _SegmentInfo({
+    required this.path,
+    required this.durationSeconds,
+    required this.estimatedBytes,
+  });
+}
 
 class RecordingProvider extends ChangeNotifier {
+  // SettingsProvider reference is required so eviction can read the current
+  // footage time limit and storage limit without going through the widget tree.
+  final SettingsProvider _settingsProvider;
+  RecordingProvider(this._settingsProvider);
+
   bool isRecording = false;
   CameraController? _controller;
   CameraController? get controller => _controller;
   DateTime? _recordingStartTime;
   DateTime? get recordingStartTime => _recordingStartTime;
-  // Tracks the start of the current camera segment (resets on each clip save).
+  // Tracks the start of the current camera segment (resets on each flush).
   // Used to compute correct in-segment offsets for clip extraction.
   DateTime? _segmentStartTime;
   DateTime? get segmentStartTime => _segmentStartTime;
   bool _isBusy = false;
   bool get isBusy => _isBusy;
-  // Accumulates all stopped segments so they can be concatenated into one
-  // continuous recording when the session ends.
-  final List<String> _segments = [];
+
+  // Completed segments accumulated during this session. Each entry carries
+  // path + duration + estimated size so eviction can be done without disk I/O.
+  final List<_SegmentInfo> _segmentInfos = [];
+  // Running totals updated by addSegment / _evictOldestIfNeeded so the check
+  // is O(1) rather than O(n) on every segment add.
+  int _totalSegmentDurationSeconds = 0;
+  int _totalSegmentEstimatedBytes = 0;
+
+  // The video bitrate (bps) set by CameraView after each controller init.
+  // Required for per-segment byte estimation: bytes = bitrate × seconds ÷ 8.
+  int? _videoBitrate;
+
+  // Fires every 5 minutes while recording to flush the current segment to disk,
+  // giving the rolling-buffer eviction a chance to drop old footage on time.
+  Timer? _flushTimer;
+  // CameraView sets this to its _doPeriodicFlush method after each controller
+  // init. The timer calls it instead of accessing the controller directly,
+  // keeping camera I/O in the widget layer where context is available.
+  VoidCallback? onFlushRequested;
 
   // Callback invoked after a recording is saved; used by ClipProvider to
   // process any pending clip that was queued during the recording stop.
@@ -31,13 +82,91 @@ class RecordingProvider extends ChangeNotifier {
   void lockBusy() => _isBusy = true;
   void unlockBusy() => _isBusy = false;
 
-  void addSegment(String path) => _segments.add(path);
-  void setSegmentStartTime(DateTime t) => _segmentStartTime = t;
-
   void setCameraController(CameraController controller) {
     _controller = controller;
   }
 
+  /// Stores the target video bitrate (bps) for the current camera configuration.
+  /// Called by CameraView after every (re)initialization so segment size
+  /// estimation in addSegment always uses the current encoding bitrate.
+  void setVideoBitrate(int bitrate) => _videoBitrate = bitrate;
+
+  void setSegmentStartTime(DateTime t) => _segmentStartTime = t;
+
+  /// Registers a completed segment and immediately enforces rolling-buffer limits.
+  ///
+  /// [path] is the on-disk path of the flushed segment file.
+  /// [durationSeconds] is how long this segment ran; used for time-limit checks
+  /// and to estimate stored bytes via bitrate × duration ÷ 8.
+  /// After adding, _evictOldestIfNeeded deletes the oldest segment(s) as needed
+  /// so the total stays within both the footage time limit and storage limit.
+  void addSegment(String path, int durationSeconds) {
+    // Estimate storage consumed by this segment. Using the fixed encoder bitrate
+    // gives reliable estimates because the camera controller is constrained to
+    // that bitrate. Fall back to 0 if bitrate isn't set yet (should not happen
+    // in normal use since setVideoBitrate is called before recording starts).
+    final estimatedBytes = _videoBitrate != null
+        ? (_videoBitrate! * durationSeconds) ~/ 8
+        : 0;
+    _segmentInfos.add(_SegmentInfo(
+      path: path,
+      durationSeconds: durationSeconds,
+      estimatedBytes: estimatedBytes,
+    ));
+    _totalSegmentDurationSeconds += durationSeconds;
+    _totalSegmentEstimatedBytes += estimatedBytes;
+    _evictOldestIfNeeded();
+  }
+
+  /// Deletes oldest segments from disk and the tracking list until accumulated
+  /// duration and estimated storage are both within the user's configured limits.
+  /// Called automatically by addSegment — no need to call it directly.
+  void _evictOldestIfNeeded() {
+    final limitSeconds = SettingsProvider.footageLimitToSeconds(
+      _settingsProvider.footageLimit,
+    );
+    final limitBytes = SettingsProvider.storageLimitToBytes(
+      _settingsProvider.storageLimit,
+    );
+    // Loop from oldest to newest, dropping until both constraints are satisfied.
+    // Design note: we only evict COMPLETED segments. The current in-progress
+    // segment (still being written by the camera controller) cannot be evicted
+    // here; the periodic flush creates checkpoints so it becomes evictable.
+    while (_segmentInfos.isNotEmpty) {
+      final overTime = _totalSegmentDurationSeconds > limitSeconds;
+      final overStorage = _totalSegmentEstimatedBytes > limitBytes;
+      if (!overTime && !overStorage) break;
+      final oldest = _segmentInfos.removeAt(0);
+      _totalSegmentDurationSeconds -= oldest.durationSeconds;
+      _totalSegmentEstimatedBytes -= oldest.estimatedBytes;
+      // Permanently delete the evicted segment — this is intentional rolling-
+      // buffer behavior, not an error. The user's chosen limits define how
+      // much history is retained.
+      try {
+        File(oldest.path).deleteSync();
+      } catch (_) {}
+    }
+  }
+
+  /// Starts the periodic 5-minute flush timer that drives rolling-buffer
+  /// enforcement during long recordings with no clip saves or settings changes.
+  void _startFlushTimer() {
+    _flushTimer?.cancel();
+    _flushTimer = Timer.periodic(const Duration(minutes: 5), (_) {
+      // Delegate the actual stop/restart to CameraView so camera I/O stays
+      // in the widget layer where the controller and context are accessible.
+      onFlushRequested?.call();
+    });
+  }
+
+  void _stopFlushTimer() {
+    _flushTimer?.cancel();
+    _flushTimer = null;
+  }
+
+  /// Toggles between recording and stopped states.
+  /// On start: clears accumulated segments, starts the flush timer.
+  /// On stop: cancels the flush timer, saves and concatenates all segments.
   Future<void> toggleRecording() async {
     if (_isBusy) return;
     if (_controller == null || !_controller!.value.isInitialized) return;
@@ -48,12 +177,20 @@ class RecordingProvider extends ChangeNotifier {
 
     try {
       if (isRecording) {
-        _segments.clear();
+        // Clear any leftover state from a previous session before starting fresh.
+        _segmentInfos.clear();
+        _totalSegmentDurationSeconds = 0;
+        _totalSegmentEstimatedBytes = 0;
         await _controller!.startVideoRecording();
         final now = DateTime.now();
         _recordingStartTime = now;
         _segmentStartTime = now;
+        // Begin periodic flushes so rolling-buffer limits are enforced even
+        // when no clips are saved and no settings changes occur.
+        _startFlushTimer();
       } else {
+        // Stop the flush timer before saving so it can't fire mid-save.
+        _stopFlushTimer();
         await _saveRecording();
       }
     } catch (e) {
@@ -87,24 +224,34 @@ class RecordingProvider extends ChangeNotifier {
     final videoPath = '${recordingsDir.path}/$id.mp4';
     final thumbnailPath = '${thumbnailsDir.path}/$id.jpg';
 
-    // Include the final segment
-    _segments.add(xFile.path);
+    // Build the full ordered path list: survived segments + live final file.
+    // Segments that were evicted by _evictOldestIfNeeded are already deleted
+    // from disk and removed from _segmentInfos, so they are not included here.
+    final allPaths = [
+      ..._segmentInfos.map((s) => s.path),
+      xFile.path,
+    ];
 
-    if (_segments.length == 1) {
-      // No clip saves interrupted this session — move the file directly.
+    if (allPaths.length == 1) {
+      // No prior segments (either none were created or all were evicted) —
+      // move the single final file directly without FFmpeg overhead.
       await File(xFile.path).copy(videoPath);
       await File(xFile.path).delete();
     } else {
-      // Clip saves caused stop/restart cycles. Concatenate all segments into
-      // one continuous recording so the viewer sees the full session.
-      await _concatenateSegments(_segments, videoPath, appDir.path);
-      for (final seg in _segments) {
+      // Concatenate surviving segments + the live final file into one
+      // continuous recording that covers whatever the rolling buffer retained.
+      await _concatenateSegments(allPaths, videoPath, appDir.path);
+      for (final path in allPaths) {
         try {
-          await File(seg).delete();
+          await File(path).delete();
         } catch (_) {}
       }
     }
-    _segments.clear();
+
+    // Clear rolling-buffer tracking state for this session.
+    _segmentInfos.clear();
+    _totalSegmentDurationSeconds = 0;
+    _totalSegmentEstimatedBytes = 0;
 
     // Get file size in bytes
     final fileSize = await File(videoPath).length();

--- a/drivecam/lib/provider/settings_provider.dart
+++ b/drivecam/lib/provider/settings_provider.dart
@@ -31,15 +31,6 @@ class SettingsProvider extends ChangeNotifier {
     }
   }
 
-  /// Maps a quality + framerate pair to a target video bitrate in bits per second.
-  /// Values are calibrated for dashcam H.264 encoding: high enough for readable
-  /// license plates and road detail, low enough to keep storage predictable.
-  /// Using fixed bitrates (rather than letting the encoder decide) is what makes
-  /// accurate storage-consumption estimates possible — if the encoder picks its
-  /// own bitrate you can't know in advance how large a file will be.
-  ///
-  /// Rough storage math: bitrate (bps) × seconds ÷ 8 = bytes.
-  /// Example: 10 Mbps × 3600 s ÷ 8 = 4.5 GB per hour at 1080p/30fps.
   static int videoBitrateForSettings(String quality, String framerate) {
     final fps = framerateToFps(framerate);
     switch (quality) {
@@ -64,9 +55,6 @@ class SettingsProvider extends ChangeNotifier {
     }
   }
 
-  /// Converts a footage time-limit string to seconds.
-  /// Used by RecordingProvider to compare total accumulated segment duration
-  /// against the user's chosen limit and evict the oldest segment when exceeded.
   static int footageLimitToSeconds(String value) {
     switch (value) {
       case '30min': return 1800;
@@ -81,9 +69,6 @@ class SettingsProvider extends ChangeNotifier {
     }
   }
 
-  /// Converts a footage storage-limit string to bytes.
-  /// Used alongside footageLimitToSeconds — whichever limit (time or storage)
-  /// is hit first determines when the oldest segment is dropped.
   static int storageLimitToBytes(String value) {
     // 1 GB = 1024^3 bytes (binary gigabytes, matching platform storage reporting)
     const gb = 1024 * 1024 * 1024;
@@ -110,6 +95,23 @@ class SettingsProvider extends ChangeNotifier {
       case '3m':  return 180;
       case '5m':  return 300;
       default:    return 120;
+    }
+  }
+
+  /// Converts a [clipStorageLimitOptions] string to bytes.
+  ///
+  /// Mirrors [storageLimitToBytes] but covers the clip-specific option set
+  /// (1 GB – 8 GB). Uses binary gigabytes (1 GB = 1024^3 bytes) to match how
+  /// platform storage is reported.
+  static int clipStorageLimitToBytes(String value) {
+    const gb = 1024 * 1024 * 1024;
+    switch (value) {
+      case '1GB': return 1 * gb;
+      case '2GB': return 2 * gb;
+      case '4GB': return 4 * gb;
+      case '6GB': return 6 * gb;
+      case '8GB': return 8 * gb;
+      default:    return 2 * gb;
     }
   }
 

--- a/drivecam/lib/provider/settings_provider.dart
+++ b/drivecam/lib/provider/settings_provider.dart
@@ -64,6 +64,42 @@ class SettingsProvider extends ChangeNotifier {
     }
   }
 
+  /// Converts a footage time-limit string to seconds.
+  /// Used by RecordingProvider to compare total accumulated segment duration
+  /// against the user's chosen limit and evict the oldest segment when exceeded.
+  static int footageLimitToSeconds(String value) {
+    switch (value) {
+      case '30min': return 1800;
+      case '1h':    return 3600;
+      case '1.5h':  return 5400;
+      case '2h':    return 7200;
+      case '3h':    return 10800;
+      case '4h':    return 14400;
+      case '5h':    return 18000;
+      case '6h':    return 21600;
+      default:      return 7200;
+    }
+  }
+
+  /// Converts a footage storage-limit string to bytes.
+  /// Used alongside footageLimitToSeconds — whichever limit (time or storage)
+  /// is hit first determines when the oldest segment is dropped.
+  static int storageLimitToBytes(String value) {
+    // 1 GB = 1024^3 bytes (binary gigabytes, matching platform storage reporting)
+    const gb = 1024 * 1024 * 1024;
+    switch (value) {
+      case '1GB':  return 1 * gb;
+      case '2GB':  return 2 * gb;
+      case '4GB':  return 4 * gb;
+      case '8GB':  return 8 * gb;
+      case '12GB': return 12 * gb;
+      case '16GB': return 16 * gb;
+      case '32GB': return 32 * gb;
+      case '64GB': return 64 * gb;
+      default:     return 4 * gb;
+    }
+  }
+
   static int clipDurationToSeconds(String value) {
     switch (value) {
       case '0s': return 0;

--- a/drivecam/lib/provider/settings_provider.dart
+++ b/drivecam/lib/provider/settings_provider.dart
@@ -31,6 +31,39 @@ class SettingsProvider extends ChangeNotifier {
     }
   }
 
+  /// Maps a quality + framerate pair to a target video bitrate in bits per second.
+  /// Values are calibrated for dashcam H.264 encoding: high enough for readable
+  /// license plates and road detail, low enough to keep storage predictable.
+  /// Using fixed bitrates (rather than letting the encoder decide) is what makes
+  /// accurate storage-consumption estimates possible — if the encoder picks its
+  /// own bitrate you can't know in advance how large a file will be.
+  ///
+  /// Rough storage math: bitrate (bps) × seconds ÷ 8 = bytes.
+  /// Example: 10 Mbps × 3600 s ÷ 8 = 4.5 GB per hour at 1080p/30fps.
+  static int videoBitrateForSettings(String quality, String framerate) {
+    final fps = framerateToFps(framerate);
+    switch (quality) {
+      case '480p':
+        if (fps <= 15) return 1000000;   // 1 Mbps
+        if (fps <= 30) return 2000000;   // 2 Mbps
+        return 3500000;                  // 3.5 Mbps @ 60fps
+      case '720p':
+        if (fps <= 15) return 3000000;   // 3 Mbps
+        if (fps <= 30) return 5000000;   // 5 Mbps
+        return 8000000;                  // 8 Mbps @ 60fps
+      case '1080p':
+        if (fps <= 15) return 6000000;   // 6 Mbps
+        if (fps <= 30) return 10000000;  // 10 Mbps
+        return 16000000;                 // 16 Mbps @ 60fps
+      case '4K':
+        if (fps <= 15) return 20000000;  // 20 Mbps
+        if (fps <= 30) return 35000000;  // 35 Mbps
+        return 50000000;                 // 50 Mbps @ 60fps
+      default:
+        return 5000000; // fallback: 720p/30fps equivalent
+    }
+  }
+
   static int clipDurationToSeconds(String value) {
     switch (value) {
       case '0s': return 0;

--- a/drivecam/lib/screens/footage/clip_display.dart
+++ b/drivecam/lib/screens/footage/clip_display.dart
@@ -1,3 +1,10 @@
+// Displays the grid of saved clips and a low-storage warning banner.
+//
+// The grid is refreshed automatically whenever a clip is saved (via
+// ClipProvider.clipSaved) or manually deleted. When the total clip storage
+// reaches or exceeds 80 % of the configured limit an orange banner is shown
+// at the top of the section so the user knows oldest clips will soon be
+// auto-deleted.
 import 'dart:io';
 import 'package:drivecam/models/clip.dart';
 import 'package:drivecam/screens/footage/footage_viewer.dart';
@@ -5,6 +12,7 @@ import 'package:drivecam/widgets/delete_button.dart';
 import 'package:flutter/material.dart';
 import 'package:provider/provider.dart';
 import '../../provider/clip_provider.dart';
+import '../../provider/settings_provider.dart';
 
 class ClipDisplay extends StatefulWidget {
   const ClipDisplay({super.key});
@@ -59,35 +67,75 @@ class _ClipDisplayState extends State<ClipDisplay> {
       return FutureBuilder<List<Clip>>(
         future: _clipsFuture,
         builder: (context, snapshot) {
-        if (snapshot.connectionState == ConnectionState.waiting) {
-          return const SizedBox(
-            height: 200,
-            child: Center(child: CircularProgressIndicator()),
+          if (snapshot.connectionState == ConnectionState.waiting) {
+            return const SizedBox(
+              height: 200,
+              child: Center(child: CircularProgressIndicator()),
+            );
+          }
+
+          final clips = snapshot.data ?? [];
+          if (clips.isEmpty) {
+            return const Center(child: Text('No clips saved'));
+          }
+
+          // Compute total clip storage and decide whether to show the warning.
+          // context.watch ensures the banner updates if the user changes the
+          // clip storage limit in settings without leaving this screen.
+          final settings = context.watch<SettingsProvider>();
+          final limitBytes = SettingsProvider.clipStorageLimitToBytes(
+              settings.clipStorageLimit);
+          final totalBytes =
+              clips.fold<int>(0, (sum, c) => sum + c.clipSize);
+
+          // Show the warning when storage is at or above 80 % of the limit.
+          final showStorageWarning = totalBytes >= (limitBytes * 0.8).floor();
+
+          return Column(
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: [
+              // Orange warning banner shown when clip storage is nearly full.
+              // The threshold is 80 % so the user has time to act before
+              // automatic eviction begins removing their oldest clips.
+              if (showStorageWarning)
+                Container(
+                  width: double.infinity,
+                  margin: const EdgeInsets.symmetric(
+                      horizontal: 8, vertical: 4),
+                  padding: const EdgeInsets.symmetric(
+                      horizontal: 12, vertical: 8),
+                  decoration: BoxDecoration(
+                    color: Colors.orange.shade700,
+                    borderRadius: BorderRadius.circular(8),
+                  ),
+                  child: Text(
+                    'Clip storage almost full — '
+                    '${formatSize(totalBytes)} of ${settings.clipStorageLimit} used. '
+                    'Oldest clips will be automatically deleted when full.',
+                    style: const TextStyle(
+                        color: Colors.white, fontSize: 12),
+                  ),
+                ),
+              GridView.builder(
+                shrinkWrap: true,
+                physics: const NeverScrollableScrollPhysics(),
+                gridDelegate:
+                    const SliverGridDelegateWithFixedCrossAxisCount(
+                  crossAxisCount: 2,
+                  crossAxisSpacing: 4,
+                  mainAxisSpacing: 4,
+                  childAspectRatio: 16 / 9,
+                ),
+                itemCount: clips.length,
+                itemBuilder: (context, index) => _ClipTile(
+                  clip: clips[index],
+                  onDeleted: _refresh,
+                ),
+              ),
+            ],
           );
-        }
-
-        final clips = snapshot.data ?? [];
-        if (clips.isEmpty) {
-          return const Center(child: Text('No clips saved'));
-        }
-
-        return GridView.builder(
-          shrinkWrap: true,
-          physics: const NeverScrollableScrollPhysics(),
-          gridDelegate: const SliverGridDelegateWithFixedCrossAxisCount(
-            crossAxisCount: 2,
-            crossAxisSpacing: 4,
-            mainAxisSpacing: 4,
-            childAspectRatio: 16 / 9,
-          ),
-          itemCount: clips.length,
-          itemBuilder: (context, index) => _ClipTile(
-            clip: clips[index],
-            onDeleted: _refresh,
-          ),
-        );
-      },
-    );
+        },
+      );
   });
   }
 }

--- a/drivecam/lib/widgets/camera_view.dart
+++ b/drivecam/lib/widgets/camera_view.dart
@@ -33,12 +33,18 @@ class _CameraViewState extends State<CameraView> {
     bool audioEnabled,
   ) async {
     _camera ??= (await availableCameras()).first;
-    // enableAudio controls whether the microphone is captured.
+    // videoBitrate is derived from quality + framerate so the encoder uses a
+    // known, fixed rate rather than a platform-chosen default. A fixed bitrate
+    // is required for accurate storage-consumption estimates elsewhere in the
+    // app (bytes = bitrate × seconds ÷ 8). audioBitrate is intentionally left
+    // at the platform default since audio storage is negligible by comparison.
+    final bitrate = SettingsProvider.videoBitrateForSettings(quality, framerate);
     final controller = CameraController(
       _camera!,
       SettingsProvider.qualityToPreset(quality),
       fps: SettingsProvider.framerateToFps(framerate),
       enableAudio: audioEnabled,
+      videoBitrate: bitrate,
     );
     await controller.initialize();
     if (!mounted) return;

--- a/drivecam/lib/widgets/camera_view.dart
+++ b/drivecam/lib/widgets/camera_view.dart
@@ -25,6 +25,9 @@ class _CameraViewState extends State<CameraView> {
   bool? _currentAudioEnabled;
   Orientation? _currentOrientation;
   Timer? _clipTimer;
+  // Cached provider reference so dispose() can null out onFlushRequested
+  // without relying on context (which may be invalid during disposal).
+  RecordingProvider? _recordingProvider;
 
   /// Initializes (or reinitializes) the [CameraController] with the given settings.
   Future<void> _initCamera(
@@ -48,11 +51,47 @@ class _CameraViewState extends State<CameraView> {
     );
     await controller.initialize();
     if (!mounted) return;
-    context.read<RecordingProvider>().setCameraController(controller);
+    // Cache the provider reference so dispose() can clean up onFlushRequested
+    // without needing a valid BuildContext.
+    _recordingProvider = context.read<RecordingProvider>();
+    _recordingProvider!.setCameraController(controller);
+    // Keep bitrate in sync with the controller so segment size estimation in
+    // addSegment always reflects the current encoding rate.
+    _recordingProvider!.setVideoBitrate(bitrate);
+    // Point the flush timer callback at this widget's _doPeriodicFlush so
+    // RecordingProvider can trigger stop/restart without holding a controller ref.
+    _recordingProvider!.onFlushRequested = _doPeriodicFlush;
     _controller = controller;
     _currentQuality = quality;
     _currentFramerate = framerate;
     _currentAudioEnabled = audioEnabled;
+  }
+
+  /// Called by RecordingProvider's 5-minute flush timer to flush the current
+  /// camera segment to disk, register it with the rolling buffer, and restart
+  /// recording — giving _evictOldestIfNeeded a chance to drop old footage.
+  Future<void> _doPeriodicFlush() async {
+    if (!mounted) return;
+    final recordingProvider = context.read<RecordingProvider>();
+    if (!recordingProvider.isRecording || recordingProvider.isBusy) return;
+
+    recordingProvider.lockBusy();
+    try {
+      // Capture segment start before stopping so the duration is accurate even
+      // if stopVideoRecording takes a moment to complete.
+      final segmentStart = recordingProvider.segmentStartTime ?? DateTime.now();
+      final xFile = await _controller!.stopVideoRecording();
+      final durationSeconds = DateTime.now().difference(segmentStart).inSeconds;
+      // addSegment accounts for duration + estimated size and triggers eviction
+      // of oldest segments if either the time or storage limit is exceeded.
+      recordingProvider.addSegment(xFile.path, durationSeconds);
+      await _controller!.startVideoRecording();
+      recordingProvider.setSegmentStartTime(DateTime.now());
+    } catch (e) {
+      debugPrint('Periodic flush failed: $e');
+    } finally {
+      recordingProvider.unlockBusy();
+    }
   }
 
   Future<void> _triggerClipSave() async {
@@ -108,10 +147,14 @@ class _CameraViewState extends State<CameraView> {
 
     recordingProvider.lockBusy();
     try {
+      // Capture segment start before stopping so duration is accurate.
+      final segmentStart = recordingProvider.segmentStartTime ?? DateTime.now();
       // Flush the current video segment to disk so no footage is lost.
       final xFile = await oldController.stopVideoRecording();
-      // Register the segment so it gets concatenated when recording ends.
-      recordingProvider.addSegment(xFile.path);
+      final durationSeconds = DateTime.now().difference(segmentStart).inSeconds;
+      // Pass duration so rolling-buffer eviction can account for this segment's
+      // time and estimated storage correctly.
+      recordingProvider.addSegment(xFile.path, durationSeconds);
 
       // Dispose the old controller before creating the new one.
       oldController.dispose();
@@ -185,6 +228,9 @@ class _CameraViewState extends State<CameraView> {
   void dispose() {
     _clipTimer?.cancel();
     _controller?.dispose();
+    // Clear the flush callback so the timer in RecordingProvider doesn't call
+    // into this widget after it has been removed from the tree.
+    _recordingProvider?.onFlushRequested = null;
     super.dispose();
   }
 

--- a/drivecam/test/provider/clip_storage_limit_test.dart
+++ b/drivecam/test/provider/clip_storage_limit_test.dart
@@ -1,0 +1,321 @@
+// Tests for ClipProvider's clip storage limit enforcement.
+//
+// These tests exercise the eviction logic that fires after every clip save.
+// They use the FFI SQLite backend + an in-memory database so no camera or
+// FFmpeg is needed — the eviction method is called directly after seeding the
+// database through the model layer.
+//
+// Design note: ClipProvider.enforceClipStorageLimit() is annotated
+// @visibleForTesting so it can be called here independently from the full
+// clip-save pipeline (which would require a live camera and FFmpeg). This is
+// the same approach used by recording_provider_test.dart, which calls
+// addSegment() to trigger eviction without a real camera.
+
+import 'dart:io';
+
+import 'package:drivecam/database/database_helper.dart';
+import 'package:drivecam/database/queries.dart';
+import 'package:drivecam/models/clip.dart';
+import 'package:drivecam/provider/clip_provider.dart';
+import 'package:drivecam/provider/recording_provider.dart';
+import 'package:drivecam/provider/settings_provider.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:shared_preferences_platform_interface/in_memory_shared_preferences_async.dart';
+import 'package:shared_preferences_platform_interface/shared_preferences_async_platform_interface.dart';
+import 'package:sqflite_common_ffi/sqflite_ffi.dart';
+
+// Opens a fresh in-memory database with the app schema applied.
+// Each test gets its own instance so no state leaks between tests.
+Future<Database> openTestDatabase() {
+  return databaseFactoryFfi.openDatabase(
+    inMemoryDatabasePath,
+    options: OpenDatabaseOptions(
+      version: 1,
+      onCreate: (db, version) async {
+        await db.execute(createRecordingTable);
+        await db.execute(createClipsTable);
+      },
+    ),
+  );
+}
+
+void main() {
+  late Database db;
+
+  // Switch sqflite to the FFI backend so tests run without mobile plugins.
+  setUpAll(() {
+    sqfliteFfiInit();
+    databaseFactory = databaseFactoryFfi;
+  });
+
+  setUp(() async {
+    db = await openTestDatabase();
+    // Inject the in-memory DB so all Clip model methods use it.
+    DatabaseHelper.setDatabaseForTesting(db);
+    // Suppress SharedPreferences platform calls from SettingsProvider setters.
+    SharedPreferencesAsyncPlatform.instance =
+        InMemorySharedPreferencesAsync.empty();
+  });
+
+  tearDown(() async {
+    DatabaseHelper.setDatabaseForTesting(null);
+    await db.close();
+  });
+
+  /// Builds a [ClipProvider] with [clipStorageLimit] set to the given option
+  /// string (must be one of clipStorageLimitOptions, e.g. '1GB').
+  /// Both the [RecordingProvider] and [SettingsProvider] are created fresh so
+  /// each test starts from a clean state.
+  ClipProvider makeProvider({required String clipStorageLimit}) {
+    final settings = SettingsProvider();
+    // Set the field directly to avoid async SharedPreferences calls.
+    settings.clipStorageLimit = clipStorageLimit;
+    final recording = RecordingProvider(settings);
+    return ClipProvider(recording, settings);
+  }
+
+  /// Inserts a clip row directly into the test database.
+  ///
+  /// [id] and [dateTime] are used to control FIFO ordering — an earlier
+  /// [dateTime] means the clip is considered older and will be evicted first.
+  /// [clipSize] is in bytes. [clipLocation] and [thumbnailLocation] are the
+  /// file paths stored in the DB (used by eviction to delete files from disk).
+  Future<void> insertTestClip({
+    required String id,
+    required String dateTime,
+    required int clipSize,
+    String clipLocation = '/clips/test.mp4',
+    String thumbnailLocation = '/thumbs/test.jpg',
+  }) async {
+    await db.rawInsert(insertClip, [
+      id,
+      dateTime,
+      'pretty $id',
+      30,         // clip_length (seconds) — irrelevant to eviction
+      clipSize,
+      'manual',
+      0,          // is_flagged
+      clipLocation,
+      thumbnailLocation,
+    ]);
+  }
+
+  // ===========================================================================
+  // No eviction when under the limit
+  // ===========================================================================
+
+  test('does not evict any clips when total size is within the limit', () async {
+    // 1 GB = 1,073,741,824 bytes. Two clips at 200 MB each = 400 MB total — well under.
+    const mb200 = 200 * 1024 * 1024;
+    await insertTestClip(id: 'clip-a', dateTime: '2026-01-01T10:00:00.000Z', clipSize: mb200);
+    await insertTestClip(id: 'clip-b', dateTime: '2026-01-02T10:00:00.000Z', clipSize: mb200);
+
+    final provider = makeProvider(clipStorageLimit: '1GB');
+    await provider.enforceClipStorageLimit();
+
+    final remaining = await Clip.loadAllClips();
+    // Both clips are under the 1 GB limit — neither should be deleted.
+    expect(remaining, hasLength(2));
+  });
+
+  // ===========================================================================
+  // Single-clip eviction
+  // ===========================================================================
+
+  // When two clips together exceed the limit, only the oldest is removed.
+  // This mirrors the dashcam rolling-window behaviour for recordings.
+  test('evicts the single oldest clip when total just exceeds the limit', () async {
+    // 600 MB each. 2 × 600 = 1,200 MB > 1 GB. After evicting clip-old: 600 MB ≤ 1 GB.
+    const mb600 = 600 * 1024 * 1024;
+    await insertTestClip(id: 'clip-old', dateTime: '2026-01-01T10:00:00.000Z', clipSize: mb600);
+    await insertTestClip(id: 'clip-new', dateTime: '2026-01-02T10:00:00.000Z', clipSize: mb600);
+
+    final provider = makeProvider(clipStorageLimit: '1GB');
+    await provider.enforceClipStorageLimit();
+
+    final remaining = await Clip.loadAllClips();
+    expect(remaining, hasLength(1));
+    // The newer clip must survive — only the oldest is evicted.
+    expect(remaining.single.id, 'clip-new');
+  });
+
+  // ===========================================================================
+  // Multi-clip eviction in a single pass
+  // ===========================================================================
+
+  // Eviction must loop until the total is back within the limit, not just
+  // remove one clip and stop. If it stopped early the app would leave the user
+  // over-limit until the next clip is saved.
+  test('evicts multiple oldest clips in one pass until within the limit', () async {
+    // 3 clips at 600 MB each = 1,800 MB.
+    // After evicting oldest: 1,200 MB > 1 GB → evict again → 600 MB ≤ 1 GB.
+    const mb600 = 600 * 1024 * 1024;
+    await insertTestClip(id: 'clip-1', dateTime: '2026-01-01T10:00:00.000Z', clipSize: mb600);
+    await insertTestClip(id: 'clip-2', dateTime: '2026-01-02T10:00:00.000Z', clipSize: mb600);
+    await insertTestClip(id: 'clip-3', dateTime: '2026-01-03T10:00:00.000Z', clipSize: mb600);
+
+    final provider = makeProvider(clipStorageLimit: '1GB');
+    await provider.enforceClipStorageLimit();
+
+    final remaining = await Clip.loadAllClips();
+    // Two oldest clips are removed; only the newest survives.
+    expect(remaining, hasLength(1));
+    expect(remaining.single.id, 'clip-3');
+  });
+
+  // ===========================================================================
+  // FIFO ordering
+  // ===========================================================================
+
+  // Eviction must always remove the chronologically oldest clip first.
+  // Removing a newer clip would cause unexpected data loss for the user.
+  test('eviction is FIFO — always removes chronologically oldest clip first',
+      () async {
+    // Three 400 MB clips. Total 1,200 MB > 1 GB → evict oldest (clip-a).
+    // Remaining 800 MB ≤ 1 GB → stop. clip-b and clip-c survive.
+    const mb400 = 400 * 1024 * 1024;
+    await insertTestClip(id: 'clip-a', dateTime: '2026-01-01T08:00:00.000Z', clipSize: mb400);
+    await insertTestClip(id: 'clip-b', dateTime: '2026-01-02T08:00:00.000Z', clipSize: mb400);
+    await insertTestClip(id: 'clip-c', dateTime: '2026-01-03T08:00:00.000Z', clipSize: mb400);
+
+    final provider = makeProvider(clipStorageLimit: '1GB');
+    await provider.enforceClipStorageLimit();
+
+    final remaining = await Clip.loadAllClips();
+    expect(remaining, hasLength(2));
+    // loadAllClips returns newest-first, so index 0 is clip-c, index 1 is clip-b.
+    expect(remaining[0].id, 'clip-c');
+    expect(remaining[1].id, 'clip-b');
+    // clip-a (oldest) must be gone.
+    expect(remaining.any((c) => c.id == 'clip-a'), isFalse);
+  });
+
+  // ===========================================================================
+  // Disk file deletion
+  // ===========================================================================
+
+  // When a clip is evicted, both its video file and thumbnail must be deleted
+  // from disk. Keeping DB rows in sync with the filesystem is not enough —
+  // the storage bytes only return to the OS once the files are gone.
+  test('evicted clip video and thumbnail files are deleted from disk', () async {
+    final tmpDir = Directory.systemTemp.createTempSync('clip_eviction_test_');
+    try {
+      final videoFile = File('${tmpDir.path}/old.mp4');
+      final thumbFile = File('${tmpDir.path}/old.jpg');
+      await videoFile.writeAsString('fake video');
+      await thumbFile.writeAsString('fake thumbnail');
+
+      const mb600 = 600 * 1024 * 1024;
+      // Insert the older clip pointing to the real temp files.
+      await insertTestClip(
+        id: 'clip-old',
+        dateTime: '2026-01-01T10:00:00.000Z',
+        clipSize: mb600,
+        clipLocation: videoFile.path,
+        thumbnailLocation: thumbFile.path,
+      );
+      // Newer clip uses fake non-existent paths (we only care about old-clip files).
+      await insertTestClip(
+        id: 'clip-new',
+        dateTime: '2026-01-02T10:00:00.000Z',
+        clipSize: mb600,
+      );
+
+      final provider = makeProvider(clipStorageLimit: '1GB');
+      await provider.enforceClipStorageLimit();
+
+      // clip-old is evicted — both its files must no longer exist on disk.
+      expect(videoFile.existsSync(), isFalse,
+          reason: 'video file should be deleted from disk on eviction');
+      expect(thumbFile.existsSync(), isFalse,
+          reason: 'thumbnail should be deleted from disk on eviction');
+    } finally {
+      // Always clean up the temp directory, even if the test fails.
+      if (tmpDir.existsSync()) tmpDir.deleteSync(recursive: true);
+    }
+  });
+
+  // ===========================================================================
+  // Missing files on disk
+  // ===========================================================================
+
+  // If a clip's file has already been removed (e.g. manual deletion outside
+  // the app, prior crash), enforceClipStorageLimit must not throw. The DB row
+  // should still be removed so the app stays consistent.
+  test('eviction with non-existent clip files does not throw', () async {
+    const mb600 = 600 * 1024 * 1024;
+    await insertTestClip(
+      id: 'clip-missing',
+      dateTime: '2026-01-01T10:00:00.000Z',
+      clipSize: mb600,
+      clipLocation: '/no/such/file.mp4',
+      thumbnailLocation: '/no/such/thumb.jpg',
+    );
+    await insertTestClip(
+      id: 'clip-ok',
+      dateTime: '2026-01-02T10:00:00.000Z',
+      clipSize: mb600,
+    );
+
+    final provider = makeProvider(clipStorageLimit: '1GB');
+
+    // The call must complete normally — missing files must not throw.
+    await expectLater(
+      provider.enforceClipStorageLimit(),
+      completes,
+    );
+
+    // The DB row is removed even when the file was already gone.
+    final remaining = await Clip.loadAllClips();
+    expect(remaining, hasLength(1));
+    expect(remaining.single.id, 'clip-ok');
+  });
+
+  // ===========================================================================
+  // Newly inserted clip is included in the total
+  // ===========================================================================
+
+  // enforceClipStorageLimit is called *after* insertClipDB, so the clip just
+  // saved counts toward the total. If it were called before, the last clip
+  // would be invisible to the check and the limit could be silently exceeded.
+  test('newly inserted clip is counted in the total before any eviction check',
+      () async {
+    // Start with one clip that already fills 90 % of the limit (963 MB of 1 GB).
+    // A second clip at 200 MB pushes the total to ~1,163 MB > 1 GB.
+    // The enforcement must detect this and evict the older clip.
+    const mb963 = 963 * 1024 * 1024;
+    const mb200 = 200 * 1024 * 1024;
+    await insertTestClip(
+      id: 'clip-big-old',
+      dateTime: '2026-01-01T10:00:00.000Z',
+      clipSize: mb963,
+    );
+    // Simulate the "just saved" clip already inserted into the DB.
+    await insertTestClip(
+      id: 'clip-new-small',
+      dateTime: '2026-01-02T10:00:00.000Z',
+      clipSize: mb200,
+    );
+
+    final provider = makeProvider(clipStorageLimit: '1GB');
+    await provider.enforceClipStorageLimit();
+
+    // The old large clip must be evicted; the newly saved small clip survives.
+    final remaining = await Clip.loadAllClips();
+    expect(remaining, hasLength(1));
+    expect(remaining.single.id, 'clip-new-small');
+  });
+
+  // ===========================================================================
+  // Edge case: no clips in DB
+  // ===========================================================================
+
+  test('does not throw when the clips table is empty', () async {
+    final provider = makeProvider(clipStorageLimit: '1GB');
+
+    await expectLater(provider.enforceClipStorageLimit(), completes);
+
+    final remaining = await Clip.loadAllClips();
+    expect(remaining, isEmpty);
+  });
+}

--- a/drivecam/test/provider/recording_provider_test.dart
+++ b/drivecam/test/provider/recording_provider_test.dart
@@ -1,0 +1,372 @@
+// Unit tests for RecordingProvider's rolling-buffer eviction logic.
+
+import 'dart:io';
+
+import 'package:drivecam/provider/recording_provider.dart';
+import 'package:drivecam/provider/settings_provider.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:shared_preferences_platform_interface/in_memory_shared_preferences_async.dart';
+import 'package:shared_preferences_platform_interface/shared_preferences_async_platform_interface.dart';
+
+void main() {
+  // Use in-memory SharedPreferences so that any SettingsProvider setter that
+  // calls SharedPreferencesAsync internally doesn't fail trying to reach the
+  // real platform plugin in the unit-test environment.
+  setUp(() {
+    SharedPreferencesAsyncPlatform.instance =
+        InMemorySharedPreferencesAsync.empty();
+  });
+
+  /// Creates a [SettingsProvider] with the given footage time and storage limits.
+  ///
+  /// [footageLimit] and [storageLimit] accept the same string values that appear
+  /// in the settings UI (e.g. '30min', '1GB'). Both default to very large values
+  /// so neither accidentally triggers eviction in tests that only care about one
+  /// of the two constraints.
+  SettingsProvider makeSettings({
+    String footageLimit = '6h',   // high default so time won't interfere
+    String storageLimit = '64GB', // high default so storage won't interfere
+  }) {
+    final s = SettingsProvider();
+    // Set fields directly rather than calling the async setters, since we only
+    // need the in-memory value for eviction checks — no persistence required.
+    s.footageLimit = footageLimit;
+    s.storageLimit = storageLimit;
+    return s;
+  }
+
+  // ===========================================================================
+  // addSegment — basic accumulation (no eviction expected)
+  // ===========================================================================
+  group('RecordingProvider.addSegment — accumulation', () {
+    // When no bitrate has been set yet, estimatedBytes falls back to 0.
+    // This is intentional: the storage limit can never be exceeded if we
+    // don't know the bitrate, so it's safer to under-count than over-count.
+    test('without a bitrate set, accumulates duration but estimates 0 bytes', () {
+      final provider = RecordingProvider(makeSettings());
+
+      provider.addSegment('/fake/seg1.mp4', 120);
+
+      expect(provider.segmentCount, 1);
+      expect(provider.totalSegmentDurationSeconds, 120);
+      expect(provider.totalSegmentEstimatedBytes, 0);
+    });
+
+    // bytes = bitrate_bps × duration_seconds ÷ 8 (bits to bytes conversion).
+    // Example: 5 Mbps × 10 s ÷ 8 = 6,250,000 bytes.
+    test('with a bitrate set, estimates bytes as bitrate × duration ÷ 8', () {
+      final provider = RecordingProvider(makeSettings());
+      provider.setVideoBitrate(5000000); // 5 Mbps
+
+      provider.addSegment('/fake/seg1.mp4', 10); // 10 seconds
+
+      // 5,000,000 × 10 ÷ 8 = 6,250,000 bytes
+      expect(provider.totalSegmentEstimatedBytes, 6250000);
+      expect(provider.totalSegmentDurationSeconds, 10);
+    });
+
+    // Calling addSegment multiple times should grow both running totals.
+    test('multiple calls accumulate duration and bytes correctly', () {
+      final provider = RecordingProvider(makeSettings());
+      provider.setVideoBitrate(8000000); // 8 Mbps
+
+      provider.addSegment('/fake/s1.mp4', 300); // 300,000,000 bytes
+      provider.addSegment('/fake/s2.mp4', 300);
+      provider.addSegment('/fake/s3.mp4', 300);
+
+      expect(provider.segmentCount, 3);
+      expect(provider.totalSegmentDurationSeconds, 900);
+      // 8,000,000 × 300 ÷ 8 = 300,000,000 per segment; × 3 = 900,000,000
+      expect(provider.totalSegmentEstimatedBytes, 900000000);
+    });
+  });
+
+  // ===========================================================================
+  // addSegment — time-limit eviction
+  // ===========================================================================
+  group('RecordingProvider.addSegment — time-limit eviction', () {
+    // When total duration is still under the limit, nothing should be evicted.
+    test('no eviction when total duration is within the limit', () {
+      // 30min = 1800s. Two 600s segments = 1200s ≤ 1800s — safe.
+      final provider = RecordingProvider(makeSettings(footageLimit: '30min'));
+
+      provider.addSegment('/fake/s1.mp4', 600);
+      provider.addSegment('/fake/s2.mp4', 600);
+
+      expect(provider.segmentCount, 2);
+      expect(provider.totalSegmentDurationSeconds, 1200);
+    });
+
+    // When the running total exceeds the limit, the oldest segment is dropped.
+    // This mirrors the dashcam rolling-window behaviour: old footage is
+    // discarded to make room for newer footage.
+    test('evicts the oldest segment once the time limit is exceeded', () {
+      // 30min = 1800s. Two 1000s segments → 2000 > 1800 → evict s1 → 1000s.
+      final provider = RecordingProvider(makeSettings(footageLimit: '30min'));
+
+      provider.addSegment('/fake/s1.mp4', 1000); // oldest — will be evicted
+      provider.addSegment('/fake/s2.mp4', 1000); // triggers eviction of s1
+
+      expect(provider.segmentCount, 1);
+      expect(provider.totalSegmentDurationSeconds, 1000);
+    });
+
+    // Eviction loops until BOTH constraints are satisfied, so multiple
+    // segments may be dropped in a single addSegment call.
+    test('evicts multiple oldest segments until within the time limit', () {
+      // 30min = 1800s. Three 700s segments → total 2100 > 1800.
+      // Evict s1 (oldest) → 1400 ≤ 1800 → stop. s2 and s3 survive.
+      final provider = RecordingProvider(makeSettings(footageLimit: '30min'));
+
+      provider.addSegment('/fake/s1.mp4', 700);
+      provider.addSegment('/fake/s2.mp4', 700);
+      provider.addSegment('/fake/s3.mp4', 700);
+
+      expect(provider.segmentCount, 2);
+      expect(provider.totalSegmentDurationSeconds, 1400);
+    });
+
+    // The eviction order must be FIFO (oldest-first), not random or newest-first.
+    // Dropping the newest segment would defeat the purpose of a rolling buffer.
+    test('eviction is FIFO — oldest segments are dropped first', () {
+      // Three 1000s segments with a 1800s limit.
+      // Adding s3: total 3000 > 1800. Evict s1 → 2000 > 1800. Evict s2 → 1000 ≤ 1800.
+      // Only s3 (the newest) should survive.
+      final provider = RecordingProvider(makeSettings(footageLimit: '30min'));
+
+      provider.addSegment('/fake/s1.mp4', 1000);
+      provider.addSegment('/fake/s2.mp4', 1000);
+      provider.addSegment('/fake/s3.mp4', 1000);
+
+      expect(provider.segmentCount, 1);
+      expect(provider.totalSegmentDurationSeconds, 1000);
+    });
+
+    // After an eviction the running total is correct, so subsequent segments
+    // are evaluated against an accurate accumulated duration — not a stale one.
+    test('subsequent segments accumulate on top of the evicted-corrected total', () {
+      final provider = RecordingProvider(makeSettings(footageLimit: '30min')); // 1800s
+
+      provider.addSegment('/fake/s1.mp4', 1000); // s1 evicted when s2 arrives
+      provider.addSegment('/fake/s2.mp4', 1000); // remaining: 1000s
+      provider.addSegment('/fake/s3.mp4', 500);  // 1000 + 500 = 1500 ≤ 1800 → no eviction
+
+      expect(provider.segmentCount, 2);
+      expect(provider.totalSegmentDurationSeconds, 1500);
+    });
+  });
+
+  // ===========================================================================
+  // addSegment — storage-limit eviction
+  // ===========================================================================
+  group('RecordingProvider.addSegment — storage-limit eviction', () {
+    // No eviction when estimated bytes are still within the storage limit.
+    // At 8 Mbps, 300s → 8,000,000 × 300 ÷ 8 = 300,000,000 bytes ≈ 286 MB.
+    // Three segments → ~858 MB, which is under 1 GB (1,073,741,824 bytes).
+    test('no eviction when total bytes are within the storage limit', () {
+      final provider = RecordingProvider(makeSettings(storageLimit: '1GB'));
+      provider.setVideoBitrate(8000000);
+
+      provider.addSegment('/fake/s1.mp4', 300);
+      provider.addSegment('/fake/s2.mp4', 300);
+      provider.addSegment('/fake/s3.mp4', 300);
+
+      expect(provider.segmentCount, 3);
+    });
+
+    // A fourth 300s segment at 8 Mbps pushes the total to ~1,200 MB, which
+    // exceeds the 1 GB limit. s1 is evicted, bringing the total back to ~858 MB.
+    test('evicts the oldest segment when the storage limit is exceeded', () {
+      final provider = RecordingProvider(makeSettings(storageLimit: '1GB'));
+      provider.setVideoBitrate(8000000); // 8 Mbps — ~286 MB per 300s segment
+
+      provider.addSegment('/fake/s1.mp4', 300);
+      provider.addSegment('/fake/s2.mp4', 300);
+      provider.addSegment('/fake/s3.mp4', 300);
+      provider.addSegment('/fake/s4.mp4', 300); // triggers eviction of s1
+
+      // s1 evicted: 3 segments remain, 900s total, 900,000,000 bytes total.
+      expect(provider.segmentCount, 3);
+      expect(provider.totalSegmentDurationSeconds, 900);
+      expect(provider.totalSegmentEstimatedBytes, 900000000);
+    });
+
+    // Confirm that storage eviction fires independently of the time limit —
+    // a large footage limit must not suppress a storage-driven eviction.
+    test('storage eviction fires even when time limit is not approached', () {
+      // footageLimit: 6h (21600s) — time will never be exceeded in this test.
+      // storageLimit: 1GB — this will be exceeded.
+      final provider = RecordingProvider(
+        makeSettings(footageLimit: '6h', storageLimit: '1GB'),
+      );
+      provider.setVideoBitrate(8000000);
+
+      for (var i = 0; i < 3; i++) {
+        provider.addSegment('/fake/s$i.mp4', 300); // no eviction yet
+      }
+      expect(provider.segmentCount, 3);
+
+      provider.addSegment('/fake/s3.mp4', 300); // triggers storage eviction
+
+      expect(provider.segmentCount, 3); // 4 added, 1 evicted = 3 remaining
+    });
+  });
+
+  // ===========================================================================
+  // addSegment — both limits active simultaneously
+  // ===========================================================================
+  group('RecordingProvider.addSegment — both limits active', () {
+    // When storage is set very high, time should be the binding constraint.
+    test('time limit is the binding constraint when hit before storage', () {
+      // footageLimit: 30min (1800s) — will trigger first.
+      // storageLimit: 64GB — unreachably high for this test.
+      // Bitrate: 1 Mbps — tiny, so byte accumulation stays negligible.
+      final provider = RecordingProvider(
+        makeSettings(footageLimit: '30min', storageLimit: '64GB'),
+      );
+      provider.setVideoBitrate(1000000); // 1 Mbps
+
+      provider.addSegment('/fake/s1.mp4', 1000); // 1000s, ~125 MB
+      provider.addSegment('/fake/s2.mp4', 1000); // total 2000 > 1800 → evict s1
+
+      expect(provider.segmentCount, 1);
+      expect(provider.totalSegmentDurationSeconds, 1000);
+    });
+
+    // When time is set very high, storage should be the binding constraint.
+    test('storage limit is the binding constraint when hit before time', () {
+      // storageLimit: 1GB — will trigger first.
+      // footageLimit: 6h (21600s) — unreachably high for this test.
+      final provider = RecordingProvider(
+        makeSettings(footageLimit: '6h', storageLimit: '1GB'),
+      );
+      provider.setVideoBitrate(8000000); // 8 Mbps — ~286 MB per 300s segment
+
+      // 3 segments: ~858 MB ≤ 1 GB (no eviction). 4th: ~1144 MB > 1 GB (evicts s1).
+      for (var i = 0; i < 4; i++) {
+        provider.addSegment('/fake/s$i.mp4', 300);
+      }
+
+      // Time: 4 × 300 = 1200s ≤ 21600s — would not evict by itself.
+      // Storage: triggered eviction of one segment.
+      expect(provider.segmentCount, 3);
+    });
+  });
+
+  // ===========================================================================
+  // File deletion on eviction
+  // ===========================================================================
+  group('RecordingProvider.addSegment — file deletion on eviction', () {
+    // When a segment is evicted, its file must be permanently deleted from disk.
+    // This is the key dashcam behaviour: old footage is not just removed from
+    // the index — the actual bytes are freed so storage stays bounded.
+    test('evicted segment file is deleted from disk', () async {
+      final provider = RecordingProvider(makeSettings(footageLimit: '30min')); // 1800s
+
+      // Create real temporary files so we can assert on disk state after eviction.
+      final tmpDir = Directory.systemTemp.createTempSync('rp_eviction_test_');
+      try {
+        final seg1 = File('${tmpDir.path}/seg1.mp4');
+        final seg2 = File('${tmpDir.path}/seg2.mp4');
+        await seg1.writeAsString('fake video content');
+        await seg2.writeAsString('fake video content');
+
+        provider.addSegment(seg1.path, 1000); // no eviction yet
+        expect(seg1.existsSync(), isTrue);    // file must still be present
+
+        provider.addSegment(seg2.path, 1000); // 2000 > 1800 → evicts seg1
+        expect(seg1.existsSync(), isFalse);   // seg1 deleted from disk
+        expect(seg2.existsSync(), isTrue);    // seg2 is the newest — survives
+      } finally {
+        // Always clean up the temp directory, even if the test fails.
+        // Without this a failed test would leave files behind on disk.
+        if (tmpDir.existsSync()) tmpDir.deleteSync(recursive: true);
+      }
+    });
+
+    // If the segment file has already been deleted (e.g. by the OS or a prior
+    // crash), _evictOldestIfNeeded wraps the delete in a try/catch so the app
+    // doesn't crash — the segment is still removed from the in-memory list.
+    test('eviction with a non-existent path does not throw', () {
+      final provider = RecordingProvider(makeSettings(footageLimit: '30min')); // 1800s
+
+      // Use paths that definitely don't exist on the file system.
+      expect(
+        () {
+          provider.addSegment('/no/such/path/seg1.mp4', 1000);
+          provider.addSegment('/no/such/path/seg2.mp4', 1000);
+        },
+        returnsNormally,
+      );
+
+      // Eviction still removed seg1 from the in-memory list.
+      expect(provider.segmentCount, 1);
+    });
+  });
+
+  // ===========================================================================
+  // Segment start time tracking
+  // ===========================================================================
+  group('RecordingProvider segment start time', () {
+    // segmentStartTime is used by CameraView and ClipProvider to calculate the
+    // duration of the current in-progress segment when it needs to be flushed.
+
+    test('segmentStartTime is null before any recording starts', () {
+      final provider = RecordingProvider(makeSettings());
+      expect(provider.segmentStartTime, isNull);
+    });
+
+    test('setSegmentStartTime stores the provided DateTime', () {
+      final provider = RecordingProvider(makeSettings());
+      final t = DateTime(2026, 5, 14, 10, 0, 0);
+
+      provider.setSegmentStartTime(t);
+
+      expect(provider.segmentStartTime, t);
+    });
+
+    test('setSegmentStartTime can be updated after the first set', () {
+      final provider = RecordingProvider(makeSettings());
+      final t1 = DateTime(2026, 5, 14, 10, 0, 0);
+      final t2 = DateTime(2026, 5, 14, 10, 5, 0);
+
+      provider.setSegmentStartTime(t1);
+      provider.setSegmentStartTime(t2);
+
+      expect(provider.segmentStartTime, t2);
+    });
+  });
+
+  // ===========================================================================
+  // onFlushRequested callback
+  // ===========================================================================
+  group('RecordingProvider.onFlushRequested', () {
+    // RecordingProvider's flush timer calls onFlushRequested without holding a
+    // direct reference to the CameraController. This keeps camera I/O in the
+    // widget layer and makes the callback mechanism itself unit-testable.
+
+    test('onFlushRequested callback is null by default', () {
+      final provider = RecordingProvider(makeSettings());
+      expect(provider.onFlushRequested, isNull);
+    });
+
+    test('assigned callback is stored and retrievable', () {
+      final provider = RecordingProvider(makeSettings());
+      var called = false;
+      provider.onFlushRequested = () { called = true; };
+
+      provider.onFlushRequested?.call();
+
+      expect(called, isTrue);
+    });
+
+    test('callback can be cleared by setting it to null', () {
+      final provider = RecordingProvider(makeSettings());
+      provider.onFlushRequested = () {};
+
+      provider.onFlushRequested = null;
+
+      expect(provider.onFlushRequested, isNull);
+    });
+  });
+}

--- a/drivecam/test/provider/settings_provider_test.dart
+++ b/drivecam/test/provider/settings_provider_test.dart
@@ -70,6 +70,158 @@ void main() {
     });
   });
 
+  // videoBitrateForSettings
+  // These tests verify the bitrate lookup table used for storage estimation.
+  // The exact values matter: bytes = bitrate × seconds ÷ 8 is used by
+  // RecordingProvider to predict how much storage each segment will consume.
+  group('SettingsProvider.videoBitrateForSettings', () {
+    test('480p at 15fps returns 1 Mbps', () {
+      expect(SettingsProvider.videoBitrateForSettings('480p', '15 fps'), 1000000);
+    });
+
+    test('480p at 30fps returns 2 Mbps', () {
+      expect(SettingsProvider.videoBitrateForSettings('480p', '30 fps'), 2000000);
+    });
+
+    test('480p at 60fps returns 3.5 Mbps', () {
+      expect(SettingsProvider.videoBitrateForSettings('480p', '60 fps'), 3500000);
+    });
+
+    test('720p at 15fps returns 3 Mbps', () {
+      expect(SettingsProvider.videoBitrateForSettings('720p', '15 fps'), 3000000);
+    });
+
+    test('720p at 30fps returns 5 Mbps', () {
+      expect(SettingsProvider.videoBitrateForSettings('720p', '30 fps'), 5000000);
+    });
+
+    test('720p at 60fps returns 8 Mbps', () {
+      expect(SettingsProvider.videoBitrateForSettings('720p', '60 fps'), 8000000);
+    });
+
+    test('1080p at 15fps returns 6 Mbps', () {
+      expect(SettingsProvider.videoBitrateForSettings('1080p', '15 fps'), 6000000);
+    });
+
+    test('1080p at 30fps returns 10 Mbps', () {
+      expect(SettingsProvider.videoBitrateForSettings('1080p', '30 fps'), 10000000);
+    });
+
+    test('1080p at 60fps returns 16 Mbps', () {
+      expect(SettingsProvider.videoBitrateForSettings('1080p', '60 fps'), 16000000);
+    });
+
+    test('4K at 15fps returns 20 Mbps', () {
+      expect(SettingsProvider.videoBitrateForSettings('4K', '15 fps'), 20000000);
+    });
+
+    test('4K at 30fps returns 35 Mbps', () {
+      expect(SettingsProvider.videoBitrateForSettings('4K', '30 fps'), 35000000);
+    });
+
+    test('4K at 60fps returns 50 Mbps', () {
+      expect(SettingsProvider.videoBitrateForSettings('4K', '60 fps'), 50000000);
+    });
+
+    test('unknown quality falls back to 5 Mbps', () {
+      expect(SettingsProvider.videoBitrateForSettings('unknown', '30 fps'), 5000000);
+    });
+
+    // Sanity-check the storage math inline: bytes = bitrate × seconds ÷ 8.
+    // 1080p/30fps = 10 Mbps → 1 hour = 3600s → 10,000,000 × 3600 ÷ 8 = 4.5 GB.
+    test('1080p/30fps × 1 hour ÷ 8 equals 4.5 GB', () {
+      final bitrate = SettingsProvider.videoBitrateForSettings('1080p', '30 fps');
+      final bytes = bitrate * 3600 ~/ 8;
+      expect(bytes, 4500000000);
+    });
+  });
+
+  // footageLimitToSeconds
+  // These values are read by RecordingProvider._evictOldestIfNeeded to enforce
+  // the rolling-buffer time limit. Every option must map to the correct seconds
+  // or eviction will fire at the wrong time.
+  group('SettingsProvider.footageLimitToSeconds', () {
+    test('maps "30min" to 1800 seconds', () {
+      expect(SettingsProvider.footageLimitToSeconds('30min'), 1800);
+    });
+
+    test('maps "1h" to 3600 seconds', () {
+      expect(SettingsProvider.footageLimitToSeconds('1h'), 3600);
+    });
+
+    test('maps "1.5h" to 5400 seconds', () {
+      expect(SettingsProvider.footageLimitToSeconds('1.5h'), 5400);
+    });
+
+    test('maps "2h" to 7200 seconds', () {
+      expect(SettingsProvider.footageLimitToSeconds('2h'), 7200);
+    });
+
+    test('maps "3h" to 10800 seconds', () {
+      expect(SettingsProvider.footageLimitToSeconds('3h'), 10800);
+    });
+
+    test('maps "4h" to 14400 seconds', () {
+      expect(SettingsProvider.footageLimitToSeconds('4h'), 14400);
+    });
+
+    test('maps "5h" to 18000 seconds', () {
+      expect(SettingsProvider.footageLimitToSeconds('5h'), 18000);
+    });
+
+    test('maps "6h" to 21600 seconds', () {
+      expect(SettingsProvider.footageLimitToSeconds('6h'), 21600);
+    });
+
+    test('unknown value falls back to 7200 seconds (2h)', () {
+      expect(SettingsProvider.footageLimitToSeconds('unknown'), 7200);
+    });
+  });
+
+  // storageLimitToBytes
+  // Uses binary gigabytes (1 GB = 1024^3 bytes) to match how platforms report
+  // storage. These values feed RecordingProvider._evictOldestIfNeeded alongside
+  // footageLimitToSeconds — whichever limit is hit first drives eviction.
+  group('SettingsProvider.storageLimitToBytes', () {
+    const gb = 1024 * 1024 * 1024;
+
+    test('maps "1GB" to 1 × 1024^3 bytes', () {
+      expect(SettingsProvider.storageLimitToBytes('1GB'), 1 * gb);
+    });
+
+    test('maps "2GB" to 2 × 1024^3 bytes', () {
+      expect(SettingsProvider.storageLimitToBytes('2GB'), 2 * gb);
+    });
+
+    test('maps "4GB" to 4 × 1024^3 bytes', () {
+      expect(SettingsProvider.storageLimitToBytes('4GB'), 4 * gb);
+    });
+
+    test('maps "8GB" to 8 × 1024^3 bytes', () {
+      expect(SettingsProvider.storageLimitToBytes('8GB'), 8 * gb);
+    });
+
+    test('maps "12GB" to 12 × 1024^3 bytes', () {
+      expect(SettingsProvider.storageLimitToBytes('12GB'), 12 * gb);
+    });
+
+    test('maps "16GB" to 16 × 1024^3 bytes', () {
+      expect(SettingsProvider.storageLimitToBytes('16GB'), 16 * gb);
+    });
+
+    test('maps "32GB" to 32 × 1024^3 bytes', () {
+      expect(SettingsProvider.storageLimitToBytes('32GB'), 32 * gb);
+    });
+
+    test('maps "64GB" to 64 × 1024^3 bytes', () {
+      expect(SettingsProvider.storageLimitToBytes('64GB'), 64 * gb);
+    });
+
+    test('unknown value falls back to 4 × 1024^3 bytes (4GB)', () {
+      expect(SettingsProvider.storageLimitToBytes('unknown'), 4 * gb);
+    });
+  });
+
   // clipDurationToSeconds
   group('SettingsProvider.clipDurationToSeconds', () {
     test('maps "0s" to 0', () {

--- a/drivecam/test/provider/settings_provider_test.dart
+++ b/drivecam/test/provider/settings_provider_test.dart
@@ -222,6 +222,46 @@ void main() {
     });
   });
 
+  // clipStorageLimitToBytes
+  // Uses binary gigabytes (1 GB = 1024^3 bytes) to match platform storage
+  // reporting. These values drive _enforceClipStorageLimit in ClipProvider —
+  // a wrong mapping would allow clips to consume more or less space than the
+  // user configured.
+  group('SettingsProvider.clipStorageLimitToBytes', () {
+    const gb = 1024 * 1024 * 1024;
+
+    test('maps "1GB" to 1 × 1024^3 bytes', () {
+      expect(SettingsProvider.clipStorageLimitToBytes('1GB'), 1 * gb);
+    });
+
+    test('maps "2GB" to 2 × 1024^3 bytes', () {
+      expect(SettingsProvider.clipStorageLimitToBytes('2GB'), 2 * gb);
+    });
+
+    test('maps "4GB" to 4 × 1024^3 bytes', () {
+      expect(SettingsProvider.clipStorageLimitToBytes('4GB'), 4 * gb);
+    });
+
+    test('maps "6GB" to 6 × 1024^3 bytes', () {
+      expect(SettingsProvider.clipStorageLimitToBytes('6GB'), 6 * gb);
+    });
+
+    test('maps "8GB" to 8 × 1024^3 bytes', () {
+      expect(SettingsProvider.clipStorageLimitToBytes('8GB'), 8 * gb);
+    });
+
+    test('unknown value falls back to 2 × 1024^3 bytes (2GB default)', () {
+      expect(SettingsProvider.clipStorageLimitToBytes('unknown'), 2 * gb);
+    });
+
+    // Verify binary vs decimal distinction: 1 GB must be 1,073,741,824 bytes
+    // (1024^3), not 1,000,000,000 bytes (10^9). Using the wrong base would
+    // allow ~7 % more clips than the user chose before eviction fires.
+    test('uses binary gigabytes, not decimal', () {
+      expect(SettingsProvider.clipStorageLimitToBytes('1GB'), 1073741824);
+    });
+  });
+
   // clipDurationToSeconds
   group('SettingsProvider.clipDurationToSeconds', () {
     test('maps "0s" to 0', () {

--- a/drivecam/test/screens/clip_display_test.dart
+++ b/drivecam/test/screens/clip_display_test.dart
@@ -1,13 +1,18 @@
-// Tests for the clipping UI: clip display and tile behavior.
+// Tests for the clipping UI: clip display, tile behavior, and storage warning.
 //
 // These tests focus on UI logic and widget behaviour (formatting, thumbnail
-// presence, navigation, and delete confirmation). They intentionally avoid
-// exercising database persistence and FFmpeg work — those are covered by
-// integration tests elsewhere.
+// presence, navigation, delete confirmation, and the low-storage warning
+// banner). They intentionally avoid exercising database persistence and FFmpeg
+// work — those are covered by integration tests elsewhere.
 //
 // Design note: This test file uses local helper functions to format duration
 // and size, rather than depending on private app implementations. This keeps
 // tests self-contained and decoupled from the app's internal structure.
+//
+// The storage warning banner is tested via a standalone _TestStorageBanner
+// widget that applies the same 80 % threshold logic as the production
+// ClipDisplay, without requiring a live database or Provider tree. This
+// approach mirrors how _TestClipTile is used for tile tests.
 
 import 'dart:io';
 
@@ -147,6 +152,119 @@ void main() {
       expect(deleted, isTrue);
     });
   });
+
+  // ===========================================================================
+  // Storage warning banner — threshold unit tests
+  // ===========================================================================
+  //
+  // These are pure calculations: no widget tree, no database. They pin down the
+  // 80 % threshold so that a change to the formula in ClipDisplay is caught
+  // immediately without needing a running app.
+
+  group('Storage warning banner threshold', () {
+    // Use 1 GB (1,073,741,824 bytes) as the limit throughout for readability.
+    const limitBytes = 1 * 1024 * 1024 * 1024;
+
+    test('warning is NOT shown when storage usage is below 80 %', () {
+      // 79 % of 1 GB = ~848 MB — should not trigger.
+      final total = (limitBytes * 0.79).floor();
+      expect(_shouldShowWarning(total, limitBytes), isFalse);
+    });
+
+    test('warning IS shown when storage usage is exactly at 80 %', () {
+      // The threshold is inclusive: >= 80 % shows the banner.
+      final total = (limitBytes * 0.8).floor();
+      expect(_shouldShowWarning(total, limitBytes), isTrue);
+    });
+
+    test('warning IS shown when storage usage is between 80 % and 100 %', () {
+      // 90 % of 1 GB.
+      final total = (limitBytes * 0.9).floor();
+      expect(_shouldShowWarning(total, limitBytes), isTrue);
+    });
+
+    test('warning IS shown when storage usage exceeds 100 % of the limit', () {
+      // Over-limit state that triggers before eviction runs.
+      final total = (limitBytes * 1.1).floor();
+      expect(_shouldShowWarning(total, limitBytes), isTrue);
+    });
+
+    test('warning is NOT shown when there are no clips (total = 0)', () {
+      expect(_shouldShowWarning(0, limitBytes), isFalse);
+    });
+
+    // Regression: confirm 79.9 % (just below threshold) does NOT show banner.
+    test('warning is NOT shown at 79.9 % usage', () {
+      final total = (limitBytes * 0.799).floor();
+      expect(_shouldShowWarning(total, limitBytes), isFalse);
+    });
+  });
+
+  // ===========================================================================
+  // Storage warning banner — widget tests
+  // ===========================================================================
+
+  group('Storage warning banner widget', () {
+    testWidgets('banner is NOT rendered when usage is below 80 %',
+        (WidgetTester tester) async {
+      const limitBytes = 1 * 1024 * 1024 * 1024;
+      final totalBelow = (limitBytes * 0.5).floor(); // 50 %
+
+      await tester.pumpWidget(MaterialApp(
+        home: Scaffold(
+          body: _TestStorageBanner(
+            totalBytes: totalBelow,
+            limitBytes: limitBytes,
+            limitLabel: '1GB',
+          ),
+        ),
+      ));
+
+      // SizedBox.shrink() is used when the banner is hidden — no orange container.
+      expect(find.byType(Container), findsNothing);
+      expect(find.textContaining('Clip storage almost full'), findsNothing);
+    });
+
+    testWidgets('banner IS rendered when usage reaches 80 %',
+        (WidgetTester tester) async {
+      const limitBytes = 1 * 1024 * 1024 * 1024;
+      final totalAt80 = (limitBytes * 0.8).floor();
+
+      await tester.pumpWidget(MaterialApp(
+        home: Scaffold(
+          body: _TestStorageBanner(
+            totalBytes: totalAt80,
+            limitBytes: limitBytes,
+            limitLabel: '1GB',
+          ),
+        ),
+      ));
+
+      expect(find.textContaining('Clip storage almost full'), findsOneWidget);
+    });
+
+    testWidgets('banner text includes the current usage and configured limit',
+        (WidgetTester tester) async {
+      // 900 MB used against a 1 GB limit — banner text must mention both.
+      const limitBytes = 1 * 1024 * 1024 * 1024;
+      const totalBytes = 900 * 1024 * 1024; // 900 MB
+
+      await tester.pumpWidget(MaterialApp(
+        home: Scaffold(
+          body: _TestStorageBanner(
+            totalBytes: totalBytes,
+            limitBytes: limitBytes,
+            limitLabel: '1GB',
+          ),
+        ),
+      ));
+
+      // Usage should appear as a formatted size string.
+      expect(find.textContaining(_formatSize(totalBytes)), findsOneWidget);
+      // The configured limit label must appear so the user knows the cap.
+      expect(find.textContaining('1GB'), findsOneWidget);
+    });
+  });
 }
 
 /// Test-only tile widget that mimics the essential behavior of the production
@@ -229,4 +347,49 @@ Widget _buildTestTile(Clip clip) {
     height: 240,
     child: _TestClipTile(clip: clip, onDeleted: () {}),
   );
+}
+
+// =============================================================================
+// Storage warning banner — unit and widget tests
+// =============================================================================
+//
+// The banner appears in ClipDisplay when total clip storage reaches or exceeds
+// 80 % of the configured limit. We test the threshold logic as a pure
+// calculation first, then verify the rendered widget shows the right content.
+
+/// Returns true when the banner should be visible — total is at or above 80 %
+/// of the limit. Mirrors the production expression in ClipDisplay exactly so
+/// a change to either will cause these tests to fail.
+bool _shouldShowWarning(int totalBytes, int limitBytes) {
+  return totalBytes >= (limitBytes * 0.8).floor();
+}
+
+/// Standalone banner widget that renders the orange storage warning using the
+/// same threshold logic as ClipDisplay. Accepts raw byte counts so tests can
+/// provide precise values without needing a real SettingsProvider or database.
+class _TestStorageBanner extends StatelessWidget {
+  final int totalBytes;
+  final int limitBytes;
+  final String limitLabel; // display string, e.g. '1GB'
+
+  const _TestStorageBanner({
+    required this.totalBytes,
+    required this.limitBytes,
+    required this.limitLabel,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    final show = totalBytes >= (limitBytes * 0.8).floor();
+    if (!show) return const SizedBox.shrink();
+    return Container(
+      color: Colors.orange.shade700,
+      padding: const EdgeInsets.all(8),
+      child: Text(
+        'Clip storage almost full — '
+        '${_formatSize(totalBytes)} of $limitLabel used. '
+        'Oldest clips will be automatically deleted when full.',
+      ),
+    );
+  }
 }


### PR DESCRIPTION
Closes #12. Adds limits for the recording, constraining it by time and storage, whichever occurs first. It also limits the number of clips that can exist at once based on the total storage size. This does not include the size of the main recording, which is separate. Adds relevant tests.