### PR TITLE
Add time-to-storage comparison for storage limit

### DIFF
--- a/drivecam/lib/widgets/settings/settings_list.dart
+++ b/drivecam/lib/widgets/settings/settings_list.dart
@@ -12,6 +12,56 @@ import 'package:provider/provider.dart';
 
 import '../../analytics/analytics_controller.dart';
 
+// Formats a byte count into a human-readable GB or MB string.
+// Returns GB with one decimal place if >= 1 GB, otherwise MB rounded.
+String _formatBytes(double bytes) {
+  final gb = bytes / (1024 * 1024 * 1024);
+  if (gb >= 1) return '${gb.toStringAsFixed(1)} GB';
+  return '${(bytes / (1024 * 1024)).toStringAsFixed(0)} MB';
+}
+
+// Computes an estimated storage size for one hour of footage and shows it in
+// a dialog. Uses the same bitrate table as the recording pipeline so the
+// estimate reflects what the app will actually write to disk.
+//
+// Formula: bytes = (video_bps + audio_bps) × 3600 s ÷ 8 bits/byte
+// Audio adds a flat 128 kbps (AAC stereo) when audio is enabled.
+const int _audioBitrate = 128000; // 128 kbps AAC stereo
+
+void _showStorageEstimateDialog(
+    BuildContext context, SettingsProvider settings) {
+  final videoBitrate =
+      SettingsProvider.videoBitrateForSettings(settings.quality, settings.framerate);
+  // Add audio bitrate only when audio recording is enabled.
+  final totalBitrate = settings.audioEnabled ? videoBitrate + _audioBitrate : videoBitrate;
+  final bytes = totalBitrate * 3600 / 8;
+  final mbps = (totalBitrate / 1000000).toStringAsFixed(2);
+  final sizeStr = _formatBytes(bytes);
+
+  final audioNote = settings.audioEnabled
+      ? 'Includes 128 kbps audio.'
+      : 'Audio is off — enable it in settings to include audio in the estimate.';
+
+  showDialog(
+    context: context,
+    builder: (context) => AlertDialog(
+      title: const Text('1-Hour Storage Estimate'),
+      content: Text(
+        'At ${settings.quality} / ${settings.framerate}, one hour of footage '
+        'uses approximately $sizeStr.\n\n'
+        'This is based on a total bitrate of $mbps Mbps. $audioNote Actual size '
+        'may vary slightly depending on scene complexity.',
+      ),
+      actions: [
+        TextButton(
+          onPressed: () => Navigator.pop(context),
+          child: const Text('Got it'),
+        ),
+      ],
+    ),
+  );
+}
+
 class SettingsList extends StatelessWidget {
   const SettingsList({
     super.key,
@@ -83,6 +133,21 @@ class SettingsList extends StatelessWidget {
               value: value,
             );
           },
+        ),
+        // Info button that estimates how much storage 1 hour of footage uses
+        // based on the currently selected quality and framerate. Tapping opens
+        // a dialog so the user can plan their storage limit accordingly.
+        Align(
+          alignment: Alignment.centerRight,
+          child: TextButton.icon(
+            style: TextButton.styleFrom(
+              padding: const EdgeInsets.symmetric(horizontal: 4, vertical: 0),
+              tapTargetSize: MaterialTapTargetSize.shrinkWrap,
+            ),
+            onPressed: () => _showStorageEstimateDialog(context, settingsProvider),
+            icon: const Icon(Icons.info_outline, size: 14),
+            label: const Text('How much space does 1 hr use?', style: TextStyle(fontSize: 12)),
+          ),
         ),
         Row(
           mainAxisAlignment: MainAxisAlignment.spaceBetween,


### PR DESCRIPTION
Added a button that displays a rough estimate of storage space used per hour of footage.