### PR TITLE
Get most of provider code under test

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -49,6 +49,9 @@ jobs:
       - name: Get dependencies
         run: flutter pub get
 
+      - name: Generate test mocks
+        run: dart run build_runner build --delete-conflicting-outputs
+
       # Run Flutter tests
       - name: Run tests
         run: flutter test -r expanded > test-results.json || true

--- a/README.md
+++ b/README.md
@@ -136,7 +136,8 @@ flutter run
 
 ```bash
 flutter analyze        # Run the linter (uses flutter_lints)
-flutter test           # Run unit tests
+dart run build_runner build --delete-conflicting-outputs  # Generate mocks for testing
+flutter test           # Run unit tests (requires that build_runner has been run at least once to generate mocks)
 flutter build apk      # Build an Android APK
 flutter build ios      # Build for iOS (requires macOS + Xcode)
 ```

--- a/drivecam/.gitignore
+++ b/drivecam/.gitignore
@@ -54,4 +54,5 @@ app.*.map.json
 /macos/Podfile
 
 
-
+# Mockito related
+*.mocks.dart

--- a/drivecam/lib/provider/clip_provider.dart
+++ b/drivecam/lib/provider/clip_provider.dart
@@ -16,7 +16,6 @@
 import 'package:flutter/material.dart';
 
 import '../analytics/analytics_controller.dart';
-import '../models/recording.dart';
 import 'recording_provider.dart';
 import 'settings_provider.dart';
 import '../utils/clip_saver.dart';

--- a/drivecam/lib/provider/clip_provider.dart
+++ b/drivecam/lib/provider/clip_provider.dart
@@ -85,7 +85,7 @@ class ClipProvider extends ChangeNotifier {
     }
     _recordingProvider.lockBusy();
     try {
-      await _clipSaver.saveClipFromLive(clipDurationSeconds, triggerType, _recordingProvider, _analytics, _settingsProvider);
+      clipSaved = await _clipSaver.saveClipFromLive(clipDurationSeconds, triggerType, _recordingProvider, _analytics, _settingsProvider);
       _clearClipProgress();
       notifyListeners();
     } catch (e) {

--- a/drivecam/lib/provider/clip_provider.dart
+++ b/drivecam/lib/provider/clip_provider.dart
@@ -13,28 +13,25 @@
 //   recording the clip duration, trigger type, and whether it was taken from
 //   a live recording or a previously saved file.
 
-import 'dart:io';
-
-import 'package:ffmpeg_kit_flutter_new/ffmpeg_kit.dart';
 import 'package:flutter/material.dart';
-import 'package:intl/intl.dart';
-import 'package:path_provider/path_provider.dart';
-import 'package:uuid/uuid.dart';
 
 import '../analytics/analytics_controller.dart';
-import '../models/clip.dart';
 import '../models/recording.dart';
 import 'recording_provider.dart';
 import 'settings_provider.dart';
+import '../utils/clip_saver.dart';
 
 class ClipProvider extends ChangeNotifier {
   final RecordingProvider _recordingProvider;
   final SettingsProvider _settingsProvider;
   final AnalyticsController _analytics;
+  late final ClipSaver _clipSaver;
 
   // _settingsProvider is needed to read clipStorageLimit during eviction.
   // _analytics is needed to track clip save events.
-  ClipProvider(this._recordingProvider, this._settingsProvider, this._analytics);
+  ClipProvider(this._recordingProvider, this._settingsProvider, this._analytics, {ClipSaver? clipSaver}) {
+    _clipSaver = clipSaver ?? ClipSaver();
+  }
 
   bool clipSaved = false;
   bool clipInProgress = false;
@@ -69,38 +66,6 @@ class ClipProvider extends ChangeNotifier {
     clipProgressEndTime = null;
   }
 
-  /// Enforces the clip storage limit by deleting the oldest clips first.
-  ///
-  /// Loads all clips from the database, sums their sizes, then removes the
-  /// oldest clip (lowest date_time) repeatedly until the total is within
-  /// SettingsProvider.clipStorageLimit. Both the video file and its thumbnail
-  /// are deleted from disk before the DB row is removed.
-  ///
-  /// Exposed without a leading underscore so that unit tests can call it
-  /// directly after seeding the database. Do not call this from production
-  /// code outside of the two save methods below.
-  @visibleForTesting
-  Future<void> enforceClipStorageLimit() async {
-    final limitBytes = SettingsProvider.clipStorageLimitToBytes(
-        _settingsProvider.clipStorageLimit);
-
-    // loadAllClips returns clips ordered date_time DESC (newest first),
-    // so the oldest clip is always at the tail of the list.
-    final clips = await Clip.loadAllClips();
-    var totalBytes = clips.fold<int>(0, (sum, c) => sum + c.clipSize);
-    int fromEnd = clips.length - 1;
-
-    while (totalBytes > limitBytes && fromEnd >= 0) {
-      final oldest = clips[fromEnd];
-      // Delete files from disk; ignore errors if files are already missing.
-      try { await File(oldest.clipLocation).delete(); } catch (_) {}
-      try { await File(oldest.thumbnailLocation).delete(); } catch (_) {}
-      await oldest.deleteClipDB();
-      totalBytes -= oldest.clipSize;
-      fromEnd--;
-    }
-  }
-
   /// Saves a clip of the last N seconds of the active recording.
   /// [secondsPre] is how many seconds before the trigger to include; used as
   /// the fallback clip length when the live recording is no longer available.
@@ -121,7 +86,8 @@ class ClipProvider extends ChangeNotifier {
     }
     _recordingProvider.lockBusy();
     try {
-      await _saveClipFromLive(clipDurationSeconds, triggerType);
+      await _clipSaver.saveClipFromLive(clipDurationSeconds, triggerType, _recordingProvider, _analytics, _settingsProvider);
+      _clearClipProgress();
       notifyListeners();
     } catch (e) {
       debugPrint('Clip save failed: $e');
@@ -135,13 +101,10 @@ class ClipProvider extends ChangeNotifier {
   Future<void> processPendingClip() async {
     final pending = _pendingClip;
     _pendingClip = null;
-    if (pending == null) return;
-    final recording = await Recording.openRecordingDB();
-    if (recording == null) return;
-    final end = recording.recordingLength;
-    if (end == 0) return;
-    final start = (end - pending.secondsPre).clamp(0, end);
-    await _saveClipFromRecording(start, end, pending.triggerType);
+
+    clipSaved = await _clipSaver.processPendingClip(pending, _analytics, _settingsProvider);
+
+    _clearClipProgress();
     notifyListeners();
   }
 
@@ -157,152 +120,13 @@ class ClipProvider extends ChangeNotifier {
     assert(endSeconds > startSeconds, 'endSeconds must be after startSeconds');
     _recordingProvider.lockBusy();
     try {
-      await _saveClipFromRecording(startSeconds, endSeconds, triggerType);
+      clipSaved = await _clipSaver.saveClipFromRecording(startSeconds, endSeconds, triggerType, _analytics, _settingsProvider);
+      _clearClipProgress();
       notifyListeners();
     } catch (e) {
       debugPrint('Clip save failed: $e');
     } finally {
       _recordingProvider.unlockBusy();
     }
-  }
-
-  Future<void> _saveClipFromLive(
-    int clipDurationSeconds,
-    String triggerType,
-  ) async {
-    final controller = _recordingProvider.controller!;
-    // Stop recording to flush the video file to disk.
-    final xFile = await controller.stopVideoRecording();
-    // Use segmentStartTime (not recordingStartTime) so the offset is relative
-    // to this segment, not the entire session.
-    final elapsed = _recordingProvider.segmentStartTime != null
-        ? DateTime.now().difference(_recordingProvider.segmentStartTime!).inSeconds
-        : clipDurationSeconds;
-
-    // Restart immediately to minimise the gap in the continuous recording.
-    await controller.startVideoRecording();
-    _recordingProvider.setSegmentStartTime(DateTime.now());
-
-    final appDir = await getApplicationDocumentsDirectory();
-    final clipsDir = Directory('${appDir.path}/clips');
-    final thumbnailsDir = Directory('${appDir.path}/thumbnails');
-    await Future.wait([
-      clipsDir.create(recursive: true),
-      thumbnailsDir.create(recursive: true),
-    ]);
-
-    final startSecs = (elapsed - clipDurationSeconds).clamp(0, elapsed);
-    final actualDuration = elapsed - startSecs;
-
-    final id = const Uuid().v4();
-    final clipPath = '${clipsDir.path}/$id.mp4';
-    final thumbnailPath = '${thumbnailsDir.path}/$id.jpg';
-    final now = DateTime.now();
-
-    // Stream-copy the clip segment instead of re-encoding.
-    // Trade-off: stream copy snaps the clip start to the nearest keyframe
-    // boundary (typically within 1-2 seconds).
-    await Future.wait([
-      FFmpegKit.execute(
-        '-y -ss $startSecs -i ${xFile.path} -t $actualDuration -c copy $clipPath',
-      ),
-      FFmpegKit.execute(
-        '-y -ss $startSecs -i ${xFile.path} -vframes 1 -q:v 2 $thumbnailPath',
-      ),
-    ]);
-
-    // Keep xFile around — it is added to segments so it can be concatenated
-    // into the full session recording when recording stops. Pass elapsed so
-    // rolling-buffer eviction in RecordingProvider can correctly account for
-    // this segment's duration and estimated storage.
-    _recordingProvider.addSegment(xFile.path, elapsed);
-
-    if (!await File(clipPath).exists()) return;
-
-    final fileSize = await File(clipPath).length();
-
-    await Clip(
-      id: id,
-      dateTime: now.toIso8601String(),
-      dateTimePretty: DateFormat('yyyy-MM-dd HH:mm').format(now),
-      clipLength: actualDuration,
-      clipSize: fileSize,
-      triggerType: triggerType,
-      isFlagged: false,
-      clipLocation: clipPath,
-      thumbnailLocation: thumbnailPath,
-    ).insertClipDB();
-    // Track the clip save event before enforcing the storage limit.
-    _analytics.trackClipSaved(
-      durationSeconds: actualDuration,
-      triggerType: triggerType,
-      fromLiveRecording: true,
-    );
-    // Remove oldest clip(s) if the total clip storage now exceeds the limit.
-    await enforceClipStorageLimit();
-    _clearClipProgress();
-    clipSaved = true;
-  }
-
-  Future<void> _saveClipFromRecording(
-    int startSeconds,
-    int endSeconds,
-    String triggerType,
-  ) async {
-    final recording = await Recording.openRecordingDB();
-    if (recording == null) return;
-
-    final appDir = await getApplicationDocumentsDirectory();
-    final clipsDir = Directory('${appDir.path}/clips');
-    final thumbnailsDir = Directory('${appDir.path}/thumbnails');
-    await Future.wait([
-      clipsDir.create(recursive: true),
-      thumbnailsDir.create(recursive: true),
-    ]);
-
-    final duration = endSeconds - startSeconds;
-
-    final id = const Uuid().v4();
-    final clipPath = '${clipsDir.path}/$id.mp4';
-    final thumbnailPath = '${thumbnailsDir.path}/$id.jpg';
-    final now = DateTime.now();
-
-    // Stream-copy the clip segment — same approach as _saveClipFromLive.
-    // Both operations read from the source recording file so they run in
-    // parallel; neither blocks the other.
-    await Future.wait([
-      FFmpegKit.execute(
-        '-y -ss $startSeconds -i ${recording.recordingLocation} -t $duration -c copy $clipPath',
-      ),
-      FFmpegKit.execute(
-        '-y -ss $startSeconds -i ${recording.recordingLocation} -vframes 1 -q:v 2 $thumbnailPath',
-      ),
-    ]);
-
-    if (!await File(clipPath).exists()) return;
-
-    final fileSize = await File(clipPath).length();
-
-    await Clip(
-      id: id,
-      dateTime: now.toIso8601String(),
-      dateTimePretty: DateFormat('yyyy-MM-dd HH:mm').format(now),
-      clipLength: duration,
-      clipSize: fileSize,
-      triggerType: triggerType,
-      isFlagged: false,
-      clipLocation: clipPath,
-      thumbnailLocation: thumbnailPath,
-    ).insertClipDB();
-    // Track the clip save event before enforcing the storage limit.
-    _analytics.trackClipSaved(
-      durationSeconds: duration,
-      triggerType: triggerType,
-      fromLiveRecording: false,
-    );
-    // Remove oldest clip(s) if the total clip storage now exceeds the limit.
-    await enforceClipStorageLimit();
-    _clearClipProgress();
-    clipSaved = true;
   }
 }

--- a/drivecam/lib/provider/sensor_provider.dart
+++ b/drivecam/lib/provider/sensor_provider.dart
@@ -137,6 +137,7 @@ class SensorProvider extends ChangeNotifier {
 
   /// Converts the current sensor state into a clip request using the same pre
   /// and post duration settings that the manual recording flow already uses.
+  @visibleForTesting
   void onTrigger() {
     // Use settings provider durations (pre + post) to match manual behavior
     final secondsPre = SettingsProvider.clipDurationToSeconds(

--- a/drivecam/lib/provider/sensor_provider.dart
+++ b/drivecam/lib/provider/sensor_provider.dart
@@ -127,7 +127,7 @@ class SensorProvider extends ChangeNotifier {
         // Trigger and reset state
         _lastTrigger = now;
         _candidateStart = null;
-        _onTrigger();
+        onTrigger();
       }
     } else {
       // Reset candidate if metric falls back below threshold
@@ -137,7 +137,7 @@ class SensorProvider extends ChangeNotifier {
 
   /// Converts the current sensor state into a clip request using the same pre
   /// and post duration settings that the manual recording flow already uses.
-  void _onTrigger() {
+  void onTrigger() {
     // Use settings provider durations (pre + post) to match manual behavior
     final secondsPre = SettingsProvider.clipDurationToSeconds(
       _settingsProvider.preDurationLength,

--- a/drivecam/lib/provider/theme_provider.dart
+++ b/drivecam/lib/provider/theme_provider.dart
@@ -42,13 +42,13 @@ class ThemeProvider extends ChangeNotifier {
     final prefs = SharedPreferencesAsync();
     bool? mode = await prefs.getBool("darkMode");
     if (mode != null) {
-      setDarkMode(mode);
+      await setDarkMode(mode);
     }
   }
 
   // Updates the app ThemeMode and persists the preference.
   // [mode] true enables dark mode, false enables light mode.
-  void setDarkMode(bool mode) async {
+  Future<void> setDarkMode(bool mode) async {
     themeMode = mode ? ThemeMode.dark : ThemeMode.light;
     notifyListeners();
 

--- a/drivecam/lib/utils/clip_saver.dart
+++ b/drivecam/lib/utils/clip_saver.dart
@@ -1,0 +1,217 @@
+import 'dart:io';
+import 'package:drivecam/provider/recording_provider.dart';
+import 'package:flutter/material.dart';
+import 'package:intl/intl.dart';
+
+import 'package:ffmpeg_kit_flutter_new/ffmpeg_kit.dart';
+import 'package:path_provider/path_provider.dart';
+import 'package:uuid/uuid.dart';
+
+import '../models/recording.dart';
+import '../models/clip.dart';
+import '../analytics/analytics_controller.dart';
+import '../provider/settings_provider.dart';
+
+class ClipSaver {
+  Future<bool> saveClipFromRecording(
+    int startSeconds,
+    int endSeconds,
+    String triggerType,
+    AnalyticsController analytics,
+    SettingsProvider settingsProvider,
+  ) async {
+    final recording = await Recording.openRecordingDB();
+    if (recording == null) return false;
+
+    final appDir = await getApplicationDocumentsDirectory();
+    final clipsDir = Directory('${appDir.path}/clips');
+    final thumbnailsDir = Directory('${appDir.path}/thumbnails');
+    await Future.wait([
+      clipsDir.create(recursive: true),
+      thumbnailsDir.create(recursive: true),
+    ]);
+
+    final duration = endSeconds - startSeconds;
+
+    final id = const Uuid().v4();
+    final clipPath = '${clipsDir.path}/$id.mp4';
+    final thumbnailPath = '${thumbnailsDir.path}/$id.jpg';
+    final now = DateTime.now();
+
+    // Stream-copy the clip segment — same approach as _saveClipFromLive.
+    // Both operations read from the source recording file so they run in
+    // parallel; neither blocks the other.
+    await Future.wait([
+      FFmpegKit.execute(
+        '-y -ss $startSeconds -i ${recording.recordingLocation} -t $duration -c copy $clipPath',
+      ),
+      FFmpegKit.execute(
+        '-y -ss $startSeconds -i ${recording.recordingLocation} -vframes 1 -q:v 2 $thumbnailPath',
+      ),
+    ]);
+
+    if (!await File(clipPath).exists()) return false;
+
+    final fileSize = await File(clipPath).length();
+
+    await Clip(
+      id: id,
+      dateTime: now.toIso8601String(),
+      dateTimePretty: DateFormat('yyyy-MM-dd HH:mm').format(now),
+      clipLength: duration,
+      clipSize: fileSize,
+      triggerType: triggerType,
+      isFlagged: false,
+      clipLocation: clipPath,
+      thumbnailLocation: thumbnailPath,
+    ).insertClipDB();
+    // Track the clip save event before enforcing the storage limit.
+    analytics.trackClipSaved(
+      durationSeconds: duration,
+      triggerType: triggerType,
+      fromLiveRecording: false,
+    );
+    // Remove oldest clip(s) if the total clip storage now exceeds the limit.
+    await enforceClipStorageLimit(settingsProvider);
+    return true;
+  }
+
+  Future<bool> saveClipFromLive(
+    int clipDurationSeconds,
+    String triggerType,
+    RecordingProvider recordingProvider,
+    AnalyticsController analytics,
+    SettingsProvider settingsProvider,
+  ) async {
+    final controller = recordingProvider.controller!;
+    // Stop recording to flush the video file to disk.
+    final xFile = await controller.stopVideoRecording();
+    // Use segmentStartTime (not recordingStartTime) so the offset is relative
+    // to this segment, not the entire session.
+    final elapsed = recordingProvider.segmentStartTime != null
+        ? DateTime.now()
+              .difference(recordingProvider.segmentStartTime!)
+              .inSeconds
+        : clipDurationSeconds;
+
+    // Restart immediately to minimise the gap in the continuous recording.
+    await controller.startVideoRecording();
+    recordingProvider.setSegmentStartTime(DateTime.now());
+
+    final appDir = await getApplicationDocumentsDirectory();
+    final clipsDir = Directory('${appDir.path}/clips');
+    final thumbnailsDir = Directory('${appDir.path}/thumbnails');
+    await Future.wait([
+      clipsDir.create(recursive: true),
+      thumbnailsDir.create(recursive: true),
+    ]);
+
+    final startSecs = (elapsed - clipDurationSeconds).clamp(0, elapsed);
+    final actualDuration = elapsed - startSecs;
+
+    final id = const Uuid().v4();
+    final clipPath = '${clipsDir.path}/$id.mp4';
+    final thumbnailPath = '${thumbnailsDir.path}/$id.jpg';
+    final now = DateTime.now();
+
+    // Stream-copy the clip segment instead of re-encoding.
+    // Trade-off: stream copy snaps the clip start to the nearest keyframe
+    // boundary (typically within 1-2 seconds).
+    await Future.wait([
+      FFmpegKit.execute(
+        '-y -ss $startSecs -i ${xFile.path} -t $actualDuration -c copy $clipPath',
+      ),
+      FFmpegKit.execute(
+        '-y -ss $startSecs -i ${xFile.path} -vframes 1 -q:v 2 $thumbnailPath',
+      ),
+    ]);
+
+    // Keep xFile around — it is added to segments so it can be concatenated
+    // into the full session recording when recording stops. Pass elapsed so
+    // rolling-buffer eviction in RecordingProvider can correctly account for
+    // this segment's duration and estimated storage.
+    recordingProvider.addSegment(xFile.path, elapsed);
+
+    if (!await File(clipPath).exists()) return false;
+
+    final fileSize = await File(clipPath).length();
+
+    await Clip(
+      id: id,
+      dateTime: now.toIso8601String(),
+      dateTimePretty: DateFormat('yyyy-MM-dd HH:mm').format(now),
+      clipLength: actualDuration,
+      clipSize: fileSize,
+      triggerType: triggerType,
+      isFlagged: false,
+      clipLocation: clipPath,
+      thumbnailLocation: thumbnailPath,
+    ).insertClipDB();
+    // Track the clip save event before enforcing the storage limit.
+    analytics.trackClipSaved(
+      durationSeconds: actualDuration,
+      triggerType: triggerType,
+      fromLiveRecording: true,
+    );
+    // Remove oldest clip(s) if the total clip storage now exceeds the limit.
+    await enforceClipStorageLimit(settingsProvider);
+    return true;
+  }
+
+  /// Saves a pending clip from the most recent recording, ending at the
+  /// recording's last frame (the most recent available footage).
+  Future<bool> processPendingClip(
+      ({int secondsPre, String triggerType})? pending,
+      AnalyticsController analytics,
+      SettingsProvider settingsProvider
+      ) async {
+    if (pending == null) return false;
+
+    final recording = await Recording.openRecordingDB();
+    if (recording == null) return false;
+    final end = recording.recordingLength;
+    if (end == 0) return false;
+    final start = (end - pending.secondsPre).clamp(0, end);
+
+    return saveClipFromRecording(start, end, pending.triggerType, analytics, settingsProvider);
+  }
+
+  /// Enforces the clip storage limit by deleting the oldest clips first.
+  ///
+  /// Loads all clips from the database, sums their sizes, then removes the
+  /// oldest clip (lowest date_time) repeatedly until the total is within
+  /// SettingsProvider.clipStorageLimit. Both the video file and its thumbnail
+  /// are deleted from disk before the DB row is removed.
+  ///
+  /// Exposed without a leading underscore so that unit tests can call it
+  /// directly after seeding the database. Do not call this from production
+  /// code outside of the two save methods below.
+  @visibleForTesting
+  static Future<void> enforceClipStorageLimit(
+    SettingsProvider settingsProvider,
+  ) async {
+    final limitBytes = SettingsProvider.clipStorageLimitToBytes(
+      settingsProvider.clipStorageLimit,
+    );
+
+    // loadAllClips returns clips ordered date_time DESC (newest first),
+    // so the oldest clip is always at the tail of the list.
+    final clips = await Clip.loadAllClips();
+    var totalBytes = clips.fold<int>(0, (sum, c) => sum + c.clipSize);
+    int fromEnd = clips.length - 1;
+
+    while (totalBytes > limitBytes && fromEnd >= 0) {
+      final oldest = clips[fromEnd];
+      // Delete files from disk; ignore errors if files are already missing.
+      try {
+        await File(oldest.clipLocation).delete();
+      } catch (_) {}
+      try {
+        await File(oldest.thumbnailLocation).delete();
+      } catch (_) {}
+      await oldest.deleteClipDB();
+      totalBytes -= oldest.clipSize;
+      fromEnd--;
+    }
+  }
+}

--- a/drivecam/pubspec.yaml
+++ b/drivecam/pubspec.yaml
@@ -42,6 +42,9 @@ dev_dependencies:
   shared_preferences_platform_interface: ^2.4.1
   # Lets the sqflite-based database tests run in a desktop test environment.
   sqflite_common_ffi: ^2.3.4+4
+  mockito: ^5.6.4
+  build_runner: ^2.15.0
+  fake_async: ^1.3.3
 
 # vosk_flutter requires permission_handler ^10.2.0, but permission_handler
 # 10.x uses the removed v1 Flutter embedding API on Android. We override it

--- a/drivecam/test/provider/clip_provider_unit_test.dart
+++ b/drivecam/test/provider/clip_provider_unit_test.dart
@@ -1,17 +1,23 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mockito/annotations.dart';
+import 'package:mockito/mockito.dart';
+
 import 'package:drivecam/analytics/analytics_client.dart';
 import 'package:drivecam/analytics/analytics_controller.dart';
 import 'package:drivecam/provider/clip_provider.dart';
 import 'package:drivecam/provider/recording_provider.dart';
 import 'package:drivecam/provider/settings_provider.dart';
-import 'package:flutter_test/flutter_test.dart';
 import 'package:shared_preferences_platform_interface/in_memory_shared_preferences_async.dart';
 import 'package:shared_preferences_platform_interface/shared_preferences_async_platform_interface.dart';
 
+@GenerateNiceMocks([MockSpec<RecordingProvider>()])
+@GenerateNiceMocks([MockSpec<SettingsProvider>()])
+@GenerateNiceMocks([MockSpec<AnalyticsController>()])
+import 'clip_provider_unit_test.mocks.dart';
+
 void main() {
-  setUp(() {
-    SharedPreferencesAsyncPlatform.instance =
-        InMemorySharedPreferencesAsync.empty();
-  });
+  late MockRecordingProvider recording;
+  late ClipProvider provider;
 
   // Helper that returns a freshly wired provider trio for tests.
   ClipProvider makeProvider({
@@ -25,11 +31,15 @@ void main() {
     return ClipProvider(r, s, a);
   }
 
+  setUp(() {
+    SharedPreferencesAsyncPlatform.instance =
+        InMemorySharedPreferencesAsync.empty();
+
+    recording = MockRecordingProvider();
+    provider = makeProvider(settings: MockSettingsProvider(), analytics: MockAnalyticsController(), recording: recording);
+  });
+
   test('markClipSaved and dismissClipNotification toggle flags and notify', () {
-    final settings = SettingsProvider();
-    final analytics = AnalyticsController(const NoopAnalyticsClient());
-    final recording = RecordingProvider(settings, analytics);
-    final provider = makeProvider(settings: settings, analytics: analytics, recording: recording);
     var notifications = 0;
     provider.addListener(() => notifications++);
 
@@ -45,11 +55,6 @@ void main() {
   });
 
   test('startClipProgress sets progress state and end time', () {
-    final settings = SettingsProvider();
-    final analytics = AnalyticsController(const NoopAnalyticsClient());
-    final recording = RecordingProvider(settings, analytics);
-    final provider = makeProvider(settings: settings, analytics: analytics, recording: recording);
-
     final before = DateTime.now();
     provider.startClipProgress(3);
     final after = DateTime.now();
@@ -65,37 +70,29 @@ void main() {
   });
 
   test('saveClipFromRecording returns early when recording is active or busy', () async {
-    final settings = SettingsProvider();
-    final analytics = AnalyticsController(const NoopAnalyticsClient());
-    final recording = RecordingProvider(settings, analytics);
-    final provider = makeProvider(settings: settings, analytics: analytics, recording: recording);
-
     // If recording is active the method must return without throwing and
     // clipSaved must remain false.
-    recording.isRecording = true;
+    when(recording.isRecording).thenReturn(true);
     await provider.saveClipFromRecording(startSeconds: 0, endSeconds: 1);
     expect(provider.clipSaved, isFalse);
 
     // If busy the method must also return early.
-    recording.isRecording = false;
-    recording.lockBusy();
+    when(recording.isRecording).thenReturn(false);
+    when(recording.isBusy).thenReturn(true);
     try {
       await provider.saveClipFromRecording(startSeconds: 0, endSeconds: 1);
       expect(provider.clipSaved, isFalse);
     } finally {
-      recording.unlockBusy();
+      when(recording.isBusy).thenReturn(false);
     }
   });
 
   test('saveClipFromLive exits early when controller is missing or not initialized', () async {
-    final settings = SettingsProvider();
-    final analytics = AnalyticsController(const NoopAnalyticsClient());
-    final recording = RecordingProvider(settings, analytics);
-    final provider = makeProvider(settings: settings, analytics: analytics, recording: recording);
-
     // Ensure recording is true but no controller has been set — method should
     // return early without throwing and leave clipSaved false.
-    recording.isRecording = true;
+    when(recording.isRecording).thenReturn(true);
+    when(recording.controller).thenReturn(null);
+
 
     await provider.saveClipFromLive(clipDurationSeconds: 5, secondsPre: 2);
     expect(provider.clipSaved, isFalse);

--- a/drivecam/test/provider/clip_provider_unit_test.dart
+++ b/drivecam/test/provider/clip_provider_unit_test.dart
@@ -1,4 +1,5 @@
 import 'package:camera/camera.dart';
+import 'dart:async';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:mockito/annotations.dart';
 import 'package:mockito/mockito.dart';
@@ -120,6 +121,36 @@ void main() {
       expect(provider.clipSaved, isTrue);
       expect(notifyCount, 1);
       verify(clipSaver.saveClipFromRecording(any, any, any, any, any));
+      verify(recording.lockBusy()).called(1);
+      verify(recording.unlockBusy()).called(1);
+    });
+
+    test('prints to debug when saving fails', () async {
+      when(recording.isRecording).thenReturn(false);
+      when(recording.isBusy).thenReturn(false);
+
+      // Assume the clip saver successfully saves the clip
+      when(clipSaver.saveClipFromRecording(any, any, any, any, any)).thenThrow(Error());
+
+      // Capture debugPrint output by intercepting print calls in a Zone.
+      final debugOutput = <String>[];
+      await Zone.current.fork(
+        specification: ZoneSpecification(
+          print: (self, parent, zone, line) {
+            debugOutput.add(line);
+            parent.print(zone, line);
+          },
+        ),
+      ).run(() async {
+        await provider.saveClipFromRecording(startSeconds: 0, endSeconds: 1);
+      });
+
+      expect(provider.clipSaved, isFalse);
+      verify(clipSaver.saveClipFromRecording(any, any, any, any, any));
+      verify(recording.lockBusy()).called(1);
+      verify(recording.unlockBusy()).called(1);
+
+      expect(debugOutput, contains(contains('Clip save failed')));
     });
   });
 
@@ -188,11 +219,47 @@ void main() {
       // Must await the async function so lockBusy, clip save, and unlockBusy complete.
       await provider.saveClipFromLive(clipDurationSeconds: 5, secondsPre: 2);
 
+      expect(provider.clipSaved, isTrue);
       verify(recording.lockBusy()).called(1);
       verify(clipSaver.saveClipFromLive(any, any, recording, analytics, settings)).called(1);
       verify(recording.unlockBusy()).called(1);
 
       expect(notifyCount, 1);
+    });
+
+    test('prints to debug when saving fails', () async {
+      when(recording.isRecording).thenReturn(true);
+      when(recording.isBusy).thenReturn(false);
+
+      final cameraController = MockCameraController();
+      final cameraValue = MockCameraValue();
+      when(cameraValue.isInitialized).thenReturn(true);
+      when(cameraController.value).thenReturn(cameraValue);
+      when(recording.controller).thenReturn(cameraController);
+
+      when(clipSaver.saveClipFromLive(any, any, any, any, any)).thenThrow(Error());
+
+      // Capture debugPrint output by intercepting print calls in a Zone.
+      final debugOutput = <String>[];
+      await Zone.current.fork(
+        specification: ZoneSpecification(
+          print: (self, parent, zone, line) {
+            debugOutput.add(line);
+            parent.print(zone, line);
+          },
+        ),
+      ).run(() async {
+        // Must await the async function so lockBusy, clip save, and unlockBusy complete.
+        await provider.saveClipFromLive(clipDurationSeconds: 5, secondsPre: 2);
+      });
+
+      expect(provider.clipSaved, isFalse);
+      verify(recording.lockBusy()).called(1);
+      verify(clipSaver.saveClipFromLive(any, any, recording, analytics, settings)).called(1);
+      verify(recording.unlockBusy()).called(1);
+
+      // Verify that a debug message containing 'Clip save failed' was printed.
+      expect(debugOutput, contains(contains('Clip save failed')));
     });
   });
 }

--- a/drivecam/test/provider/clip_provider_unit_test.dart
+++ b/drivecam/test/provider/clip_provider_unit_test.dart
@@ -1,3 +1,4 @@
+import 'package:camera/camera.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:mockito/annotations.dart';
 import 'package:mockito/mockito.dart';
@@ -7,28 +8,37 @@ import 'package:drivecam/analytics/analytics_controller.dart';
 import 'package:drivecam/provider/clip_provider.dart';
 import 'package:drivecam/provider/recording_provider.dart';
 import 'package:drivecam/provider/settings_provider.dart';
+import 'package:drivecam/utils/clip_saver.dart';
 import 'package:shared_preferences_platform_interface/in_memory_shared_preferences_async.dart';
 import 'package:shared_preferences_platform_interface/shared_preferences_async_platform_interface.dart';
 
 @GenerateNiceMocks([MockSpec<RecordingProvider>()])
 @GenerateNiceMocks([MockSpec<SettingsProvider>()])
 @GenerateNiceMocks([MockSpec<AnalyticsController>()])
+@GenerateNiceMocks([MockSpec<ClipSaver>()])
+@GenerateNiceMocks([MockSpec<CameraController>()])
+@GenerateNiceMocks([MockSpec<CameraValue>()])
 import 'clip_provider_unit_test.mocks.dart';
 
 void main() {
   late MockRecordingProvider recording;
+  late MockClipSaver clipSaver;
+  late MockSettingsProvider settings;
+  late MockAnalyticsController analytics;
   late ClipProvider provider;
+  late int notifyCount;
 
   // Helper that returns a freshly wired provider trio for tests.
   ClipProvider makeProvider({
     SettingsProvider? settings,
     AnalyticsController? analytics,
     RecordingProvider? recording,
+    ClipSaver? clipSaver,
   }) {
     final s = settings ?? SettingsProvider();
     final a = analytics ?? AnalyticsController(const NoopAnalyticsClient());
     final r = recording ?? RecordingProvider(s, a);
-    return ClipProvider(r, s, a);
+    return ClipProvider(r, s, a, clipSaver: clipSaver);
   }
 
   setUp(() {
@@ -36,22 +46,30 @@ void main() {
         InMemorySharedPreferencesAsync.empty();
 
     recording = MockRecordingProvider();
-    provider = makeProvider(settings: MockSettingsProvider(), analytics: MockAnalyticsController(), recording: recording);
+    clipSaver = MockClipSaver();
+    settings = MockSettingsProvider();
+    analytics = MockAnalyticsController();
+    provider = makeProvider(
+      settings: settings,
+      analytics: analytics,
+      recording: recording,
+      clipSaver: clipSaver,
+    );
+
+    notifyCount = 0;
+    provider.addListener(() => notifyCount++);
   });
 
   test('markClipSaved and dismissClipNotification toggle flags and notify', () {
-    var notifications = 0;
-    provider.addListener(() => notifications++);
-
     expect(provider.clipSaved, isFalse);
 
     provider.markClipSaved();
     expect(provider.clipSaved, isTrue);
-    expect(notifications, 1);
+    expect(notifyCount, 1);
 
     provider.dismissClipNotification();
     expect(provider.clipSaved, isFalse);
-    expect(notifications, 2);
+    expect(notifyCount, 2);
   });
 
   test('startClipProgress sets progress state and end time', () {
@@ -67,34 +85,114 @@ void main() {
     expect(diffFromNow.inSeconds, inInclusiveRange(3, 4));
     expect(provider.clipProgressEndTime!.isAfter(before), isTrue);
     expect(provider.clipProgressEndTime!.isBefore(after.add(const Duration(seconds: 5))), isTrue);
+
+    expect(notifyCount, 1);
   });
 
-  test('saveClipFromRecording returns early when recording is active or busy', () async {
-    // If recording is active the method must return without throwing and
-    // clipSaved must remain false.
-    when(recording.isRecording).thenReturn(true);
-    await provider.saveClipFromRecording(startSeconds: 0, endSeconds: 1);
-    expect(provider.clipSaved, isFalse);
-
-    // If busy the method must also return early.
-    when(recording.isRecording).thenReturn(false);
-    when(recording.isBusy).thenReturn(true);
-    try {
+  group('ClipProvider.saveClipFromRecording', () {
+    test('saveClipFromRecording returns early when recording is active or busy', () async {
+      // If recording is active the method must return without throwing and
+      // clipSaved must remain false.
+      when(recording.isRecording).thenReturn(true);
       await provider.saveClipFromRecording(startSeconds: 0, endSeconds: 1);
+      verifyNever(clipSaver.saveClipFromRecording(any, any, any, any, any));
       expect(provider.clipSaved, isFalse);
-    } finally {
+
+      // If busy the method must also return early.
+      when(recording.isRecording).thenReturn(false);
+      when(recording.isBusy).thenReturn(true);
+      try {
+        await provider.saveClipFromRecording(startSeconds: 0, endSeconds: 1);
+        expect(provider.clipSaved, isFalse);
+      } finally {
+        when(recording.isBusy).thenReturn(false);
+      }
+    });
+
+    test('saves clip when recording is inactive and not busy', () async {
+      when(recording.isRecording).thenReturn(false);
       when(recording.isBusy).thenReturn(false);
-    }
+
+      // Assume the clip saver successfully saves the clip
+      when(clipSaver.saveClipFromRecording(any, any, any, any, any)).thenAnswer((_) async => true);
+
+      await provider.saveClipFromRecording(startSeconds: 0, endSeconds: 1);
+      expect(provider.clipSaved, isTrue);
+      expect(notifyCount, 1);
+      verify(clipSaver.saveClipFromRecording(any, any, any, any, any));
+    });
   });
 
-  test('saveClipFromLive exits early when controller is missing or not initialized', () async {
-    // Ensure recording is true but no controller has been set — method should
-    // return early without throwing and leave clipSaved false.
-    when(recording.isRecording).thenReturn(true);
-    when(recording.controller).thenReturn(null);
+  group('ClipProvider.saveClipFromLive', () {
+    test('exits early when controller is missing or not initialized', () async {
+      // Ensure recording is true but no controller has been set — method should
+      // return early without throwing and leave clipSaved false.
+      when(recording.isRecording).thenReturn(true);
+      when(recording.controller).thenReturn(null);
 
+      await provider.saveClipFromLive(clipDurationSeconds: 5, secondsPre: 2);
+      expect(provider.clipSaved, isFalse);
 
-    await provider.saveClipFromLive(clipDurationSeconds: 5, secondsPre: 2);
-    expect(provider.clipSaved, isFalse);
+      // Also check when controller is not initialized
+      final cameraController = MockCameraController();
+      final cameraValue = MockCameraValue();
+      when(cameraValue.isInitialized).thenReturn(false);
+      when(cameraController.value).thenReturn(cameraValue);
+
+      when(recording.isRecording).thenReturn(true);
+      when(recording.controller).thenReturn(cameraController);
+
+      await provider.saveClipFromLive(clipDurationSeconds: 5, secondsPre: 2);
+      expect(provider.clipSaved, isFalse);
+    });
+
+    test('processes pending clip when idle and exits early when busy', () async {
+      // Use concrete typed mocks for non-nullable params to avoid Null matcher type issues.
+      when(clipSaver.processPendingClip(any, analytics, settings)).thenAnswer((_) async => true);
+
+      when(recording.isRecording).thenReturn(false);
+      when(recording.isBusy).thenReturn(false);
+      await provider.saveClipFromLive(clipDurationSeconds: 5, secondsPre: 2);
+      verifyNever(clipSaver.saveClipFromLive(any, any, any, any, any));
+      // When not recording and not busy, saveClipFromLive processes the pending clip immediately.
+      verify(clipSaver.processPendingClip(any, analytics, settings)).called(1);
+      expect(provider.clipSaved, isTrue);
+
+      // Reset the notification flag so we can verify the busy branch leaves state unchanged.
+      provider.dismissClipNotification();
+      expect(provider.clipSaved, isFalse);
+
+      // If busy the method must also return early.
+      when(recording.isRecording).thenReturn(true);
+      when(recording.isBusy).thenReturn(true);
+      await provider.saveClipFromLive(clipDurationSeconds: 5, secondsPre: 2);
+      verifyNever(clipSaver.saveClipFromLive(any, any, any, any, any));
+      expect(provider.clipSaved, isFalse);
+      verifyNoMoreInteractions(clipSaver);
+
+      await provider.saveClipFromLive(clipDurationSeconds: 5, secondsPre: 2);
+    });
+
+    test('saves clip when recording and not busy', () async {
+      when(recording.isRecording).thenReturn(true);
+      when(recording.isBusy).thenReturn(false);
+
+      final cameraController = MockCameraController();
+      final cameraValue = MockCameraValue();
+      when(cameraValue.isInitialized).thenReturn(true);
+      when(cameraController.value).thenReturn(cameraValue);
+      when(recording.controller).thenReturn(cameraController);
+
+      when(clipSaver.saveClipFromLive(any, any, any, any, any)).thenAnswer((_) async => true);
+
+      // Must await the async function so lockBusy, clip save, and unlockBusy complete.
+      await provider.saveClipFromLive(clipDurationSeconds: 5, secondsPre: 2);
+
+      verify(recording.lockBusy()).called(1);
+      verify(clipSaver.saveClipFromLive(any, any, recording, analytics, settings)).called(1);
+      verify(recording.unlockBusy()).called(1);
+
+      expect(notifyCount, 1);
+    });
   });
 }

--- a/drivecam/test/provider/sensor_provider_test.dart
+++ b/drivecam/test/provider/sensor_provider_test.dart
@@ -1,0 +1,206 @@
+// Sensor provider unit tests, impact detection logic is tested in sensor_provider_impact_test.dart with CSV fixtures that replay real sensor data.
+
+import 'package:fake_async/fake_async.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mockito/annotations.dart';
+import 'package:mockito/mockito.dart';
+
+import 'package:drivecam/provider/sensor_provider.dart';
+
+import 'package:drivecam/provider/recording_provider.dart';
+import 'package:drivecam/provider/clip_provider.dart';
+import 'package:drivecam/provider/settings_provider.dart';
+import 'package:drivecam/analytics/analytics_controller.dart';
+import 'package:drivecam/services/sensor_service.dart';
+
+
+@GenerateNiceMocks([MockSpec<RecordingProvider>()])
+@GenerateNiceMocks([MockSpec<ClipProvider>()])
+@GenerateNiceMocks([MockSpec<SettingsProvider>()])
+@GenerateNiceMocks([MockSpec<AnalyticsController>()])
+@GenerateNiceMocks([MockSpec<SensorEventSource>()])
+import 'sensor_provider_test.mocks.dart';
+
+void main() {
+  setUp(() {
+
+  });
+
+  group('SensorProvider', () {
+    test('listens to recording state changes', () {
+      final analyticsController = MockAnalyticsController();
+      final settingsProvider = MockSettingsProvider();
+      final recordingProvider = MockRecordingProvider();
+      final clipProvider = MockClipProvider();
+
+      final sensorProvider = SensorProvider(
+        recordingProvider,
+        clipProvider,
+        settingsProvider,
+      );
+
+      expect(sensorProvider, isNotNull);
+      verify(recordingProvider.addListener(any));
+    });
+  });
+
+  group('SensorProvider.setEnabled', () {
+    late SensorProvider sensorProvider;
+    late int notifyCount = 0;
+
+    late MockRecordingProvider recordingProvider;
+    late MockSensorEventSource sensorEventSource;
+
+    setUp(() {
+      recordingProvider = MockRecordingProvider();
+      sensorEventSource = MockSensorEventSource();
+
+      sensorProvider = SensorProvider(
+          recordingProvider,
+          MockClipProvider(),
+          MockSettingsProvider(),
+          sensorSource: sensorEventSource
+      );
+      notifyCount = 0;
+      sensorProvider.addListener(() => notifyCount++ );
+    });
+
+    test('starts listening when enabled and recording, then notifies listeners', () {
+      when(recordingProvider.isRecording).thenReturn(true);
+
+      sensorProvider.setEnabled(true);
+      expect(sensorProvider.enabled, isTrue);
+      expect(notifyCount, 1);
+
+      verify(sensorEventSource.start()).called(1);
+      verify(sensorEventSource.userAccelerometerStream);
+      verify(sensorEventSource.gyroscopeStream);
+    });
+
+    test('just notifies listeners when enabled and not recording', () {
+      when(recordingProvider.isRecording).thenReturn(false);
+
+      sensorProvider.setEnabled(true);
+      expect(sensorProvider.enabled, isTrue);
+      expect(notifyCount, 1);
+
+      verifyNever(sensorEventSource.start());
+      verifyNever(sensorEventSource.userAccelerometerStream);
+      verifyNever(sensorEventSource.gyroscopeStream);
+    });
+
+    test('stops listening when disabled, then notifies listeners', () {
+      when(recordingProvider.isRecording).thenReturn(true);
+
+      sensorProvider.setEnabled(false);
+      expect(sensorProvider.enabled, isFalse);
+      expect(notifyCount, 1);
+
+      verify(sensorEventSource.stop()).called(1);
+    });
+  });
+
+  group('SensorProvider._onRecordingChanged', () {
+    late SensorProvider sensorProvider;
+
+    late RecordingProvider recordingProvider;
+    late MockSensorEventSource sensorEventSource;
+
+    setUp(() {
+      recordingProvider = RecordingProvider(MockSettingsProvider(), MockAnalyticsController());
+      sensorEventSource = MockSensorEventSource();
+
+      sensorProvider = SensorProvider(
+          recordingProvider,
+          MockClipProvider(),
+          MockSettingsProvider(),
+          sensorSource: sensorEventSource
+      );
+    });
+
+    test('listens when recording is started and provider is enabled', () {
+      recordingProvider.isRecording = true;
+      recordingProvider.notifyListeners();
+
+      verify(sensorEventSource.start()).called(1);
+      verify(sensorEventSource.userAccelerometerStream);
+      verify(sensorEventSource.gyroscopeStream);
+    });
+
+    test('stops listening when recording is stopped and provider is enabled', () {
+      recordingProvider.isRecording = false;
+      recordingProvider.notifyListeners();
+
+      verify(sensorEventSource.stop()).called(1);
+      verifyNever(sensorEventSource.userAccelerometerStream);
+      verifyNever(sensorEventSource.gyroscopeStream);
+    });
+
+    test("doesn't do anything when disabled", () {
+      sensorProvider.setEnabled(false);
+
+      recordingProvider.isRecording = true;
+      recordingProvider.notifyListeners();
+
+      verifyNever(sensorEventSource.start());
+      verifyNever(sensorEventSource.userAccelerometerStream);
+      verifyNever(sensorEventSource.gyroscopeStream);
+    });
+  });
+
+  group('SensorProvider.onTrigger', () {
+    late SensorProvider sensorProvider;
+
+    late MockSettingsProvider settingsProvider;
+    late MockClipProvider clipProvider;
+
+    setUp(() {
+      settingsProvider = MockSettingsProvider();
+      clipProvider = MockClipProvider();
+
+      sensorProvider = SensorProvider(
+          MockRecordingProvider(),
+          clipProvider,
+          settingsProvider,
+          sensorSource: MockSensorEventSource()
+      );
+    });
+
+    test('saves a clip immediately when post duration clip length is 0', () {
+      when(settingsProvider.preDurationLength).thenReturn('5s');
+      when(settingsProvider.postDurationLength).thenReturn('0s');
+
+      sensorProvider.onTrigger();
+
+      verify(clipProvider.saveClipFromLive(clipDurationSeconds: 5, secondsPre: 5, triggerType: 'sensor')).called(1);
+    });
+
+    test('starts a clip save when post duration clip length is >0', () {
+      when(settingsProvider.preDurationLength).thenReturn('5s');
+      when(settingsProvider.postDurationLength).thenReturn('5s');
+
+      fakeAsync((async) {
+        sensorProvider.onTrigger();
+
+        verify(clipProvider.startClipProgress(5)).called(1);
+
+        // Timer hasn't fired yet, so clip shouldn't be saved
+        verifyNever(clipProvider.saveClipFromLive(
+            clipDurationSeconds: anyNamed("clipDurationSeconds"),
+            secondsPre: anyNamed("secondsPre"),
+            triggerType: anyNamed("triggerType"))
+        );
+
+        // Advance time to trigger the timer
+        async.elapse(const Duration(seconds: 5));
+
+        // Clip should have been saved now
+        verify(clipProvider.saveClipFromLive(
+            clipDurationSeconds: 5 + 5,
+            secondsPre: 5,
+            triggerType: 'sensor')
+        ).called(1);
+      });
+    });
+  });
+}

--- a/drivecam/test/provider/sensor_provider_test.dart
+++ b/drivecam/test/provider/sensor_provider_test.dart
@@ -28,7 +28,6 @@ void main() {
 
   group('SensorProvider', () {
     test('listens to recording state changes', () {
-      final analyticsController = MockAnalyticsController();
       final settingsProvider = MockSettingsProvider();
       final recordingProvider = MockRecordingProvider();
       final clipProvider = MockClipProvider();

--- a/drivecam/test/provider/settings_provider_test.dart
+++ b/drivecam/test/provider/settings_provider_test.dart
@@ -356,6 +356,12 @@ void main() {
       expect(notifyCount, 1);
     });
 
+    test('setVoiceClipEnabled updates state and notifies', () {
+      settings.setVoiceClipEnabled(true);
+      expect(settings.voiceClipEnabled, isTrue);
+      expect(notifyCount, 1);
+    });
+
     test('setAudioEnabled to false updates state and notifies', () {
       settings.setAudioEnabled(false);
       expect(settings.audioEnabled, isFalse);

--- a/drivecam/test/provider/theme_provider_test.dart
+++ b/drivecam/test/provider/theme_provider_test.dart
@@ -9,8 +9,12 @@ import 'package:shared_preferences_platform_interface/shared_preferences_async_p
 
 void main() {
   late ThemeProvider themeProvider;
+  late int notifyCount;
+
   setUp(() {
     themeProvider = ThemeProvider();
+    notifyCount = 0;
+    themeProvider.addListener(() => notifyCount++);
   });
 
   group('ThemeProvider.setDarkMode', () {
@@ -20,21 +24,23 @@ void main() {
             'darkMode': false,
           });
 
-      themeProvider.setDarkMode(true);
+      await themeProvider.setDarkMode(true);
 
+      expect(notifyCount, 1);
       expect(themeProvider.themeMode, ThemeMode.dark);
       final prefs = SharedPreferencesAsyncPlatform.instance;
       expect(await prefs!.getBool('darkMode', SharedPreferencesOptions()), true);
     });
 
-    test('sets theme to light and saves preference', () async {
+    test('sets theme to light, saves preference, and notifies listeners', () async {
       SharedPreferencesAsyncPlatform.instance =
           InMemorySharedPreferencesAsync.withData({
             'darkMode': true,
           });
 
-      themeProvider.setDarkMode(false);
+      await themeProvider.setDarkMode(false);
 
+      expect(notifyCount, 1);
       expect(themeProvider.themeMode, ThemeMode.light);
       final prefs = SharedPreferencesAsyncPlatform.instance;
       expect(await prefs!.getBool('darkMode', SharedPreferencesOptions()), false);

--- a/drivecam/test/provider/theme_provider_test.dart
+++ b/drivecam/test/provider/theme_provider_test.dart
@@ -1,0 +1,67 @@
+// Theme provider tests
+
+import 'package:drivecam/provider/theme_provider.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+import 'package:shared_preferences_platform_interface/in_memory_shared_preferences_async.dart';
+import 'package:shared_preferences_platform_interface/shared_preferences_async_platform_interface.dart';
+
+void main() {
+  late ThemeProvider themeProvider;
+  setUp(() {
+    themeProvider = ThemeProvider();
+  });
+
+  group('ThemeProvider.setDarkMode', () {
+    test('sets theme to dark and saves preference', () async {
+      SharedPreferencesAsyncPlatform.instance =
+          InMemorySharedPreferencesAsync.withData({
+            'darkMode': false,
+          });
+
+      themeProvider.setDarkMode(true);
+
+      expect(themeProvider.themeMode, ThemeMode.dark);
+      final prefs = SharedPreferencesAsyncPlatform.instance;
+      expect(await prefs!.getBool('darkMode', SharedPreferencesOptions()), true);
+    });
+
+    test('sets theme to light and saves preference', () async {
+      SharedPreferencesAsyncPlatform.instance =
+          InMemorySharedPreferencesAsync.withData({
+            'darkMode': true,
+          });
+
+      themeProvider.setDarkMode(false);
+
+      expect(themeProvider.themeMode, ThemeMode.light);
+      final prefs = SharedPreferencesAsyncPlatform.instance;
+      expect(await prefs!.getBool('darkMode', SharedPreferencesOptions()), false);
+    });
+  });
+
+  group('ThemeProvider.loadDarkModePrefs', () {
+    test('sets theme to dark when darkMode is true', () async {
+      SharedPreferencesAsyncPlatform.instance =
+          InMemorySharedPreferencesAsync.withData({
+            'darkMode': true,
+          });
+
+      await themeProvider.loadDarkModePrefs();
+
+      expect(themeProvider.themeMode, ThemeMode.dark);
+    });
+
+    test('sets theme to light when darkMode is false', () async {
+      SharedPreferencesAsyncPlatform.instance =
+          InMemorySharedPreferencesAsync.withData({
+            'darkMode': false,
+          });
+
+      await themeProvider.loadDarkModePrefs();
+
+      expect(themeProvider.themeMode, ThemeMode.light);
+    });
+  });
+}

--- a/drivecam/test/utils/clip_saver_storage_limit_test.dart
+++ b/drivecam/test/utils/clip_saver_storage_limit_test.dart
@@ -1,26 +1,21 @@
-// Tests for ClipProvider's clip storage limit enforcement.
+// Tests for ClipSaver's clip storage limit enforcement.
 //
 // These tests exercise the eviction logic that fires after every clip save.
 // They use the FFI SQLite backend + an in-memory database so no camera or
 // FFmpeg is needed — the eviction method is called directly after seeding the
 // database through the model layer.
 //
-// Design note: ClipProvider.enforceClipStorageLimit() is annotated
+// Design note: ClipSaver.enforceClipStorageLimit() is annotated
 // @visibleForTesting so it can be called here independently from the full
-// clip-save pipeline (which would require a live camera and FFmpeg). This is
-// the same approach used by recording_provider_test.dart, which calls
-// addSegment() to trigger eviction without a real camera.
+// clip-save pipeline (which would require a live camera and FFmpeg).
 
 import 'dart:io';
 
-import 'package:drivecam/analytics/analytics_client.dart';
-import 'package:drivecam/analytics/analytics_controller.dart';
 import 'package:drivecam/database/database_helper.dart';
 import 'package:drivecam/database/queries.dart';
 import 'package:drivecam/models/clip.dart';
-import 'package:drivecam/provider/clip_provider.dart';
-import 'package:drivecam/provider/recording_provider.dart';
 import 'package:drivecam/provider/settings_provider.dart';
+import 'package:drivecam/utils/clip_saver.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:shared_preferences_platform_interface/in_memory_shared_preferences_async.dart';
 import 'package:shared_preferences_platform_interface/shared_preferences_async_platform_interface.dart';
@@ -64,19 +59,14 @@ void main() {
     await db.close();
   });
 
-  /// Builds a [ClipProvider] with [clipStorageLimit] set to the given option
-  /// string (must be one of clipStorageLimitOptions, e.g. '1GB').
-  /// Both the [RecordingProvider] and [SettingsProvider] are created fresh so
-  /// each test starts from a clean state.
-  ClipProvider makeProvider({required String clipStorageLimit}) {
+  /// Builds a [SettingsProvider] with [clipStorageLimit] set to the given
+  /// option string (must be one of clipStorageLimitOptions, e.g. '1GB').
+  /// Tests pass this settings object into [ClipSaver.enforceClipStorageLimit].
+  SettingsProvider makeSettings({required String clipStorageLimit}) {
     final settings = SettingsProvider();
     // Set the field directly to avoid async SharedPreferences calls.
     settings.clipStorageLimit = clipStorageLimit;
-    // NoopAnalyticsClient.isConfigured returns false, so canTrack is always
-    // false — no events are ever sent to Amplitude during tests.
-    final analytics = AnalyticsController(const NoopAnalyticsClient());
-    final recording = RecordingProvider(settings, analytics);
-    return ClipProvider(recording, settings, analytics);
+    return settings;
   }
 
   /// Inserts a clip row directly into the test database.
@@ -115,8 +105,8 @@ void main() {
     await insertTestClip(id: 'clip-a', dateTime: '2026-01-01T10:00:00.000Z', clipSize: mb200);
     await insertTestClip(id: 'clip-b', dateTime: '2026-01-02T10:00:00.000Z', clipSize: mb200);
 
-    final provider = makeProvider(clipStorageLimit: '1GB');
-    await provider.enforceClipStorageLimit();
+    final settings = makeSettings(clipStorageLimit: '1GB');
+    await ClipSaver.enforceClipStorageLimit(settings);
 
     final remaining = await Clip.loadAllClips();
     // Both clips are under the 1 GB limit — neither should be deleted.
@@ -135,8 +125,8 @@ void main() {
     await insertTestClip(id: 'clip-old', dateTime: '2026-01-01T10:00:00.000Z', clipSize: mb600);
     await insertTestClip(id: 'clip-new', dateTime: '2026-01-02T10:00:00.000Z', clipSize: mb600);
 
-    final provider = makeProvider(clipStorageLimit: '1GB');
-    await provider.enforceClipStorageLimit();
+    final settings = makeSettings(clipStorageLimit: '1GB');
+    await ClipSaver.enforceClipStorageLimit(settings);
 
     final remaining = await Clip.loadAllClips();
     expect(remaining, hasLength(1));
@@ -159,8 +149,8 @@ void main() {
     await insertTestClip(id: 'clip-2', dateTime: '2026-01-02T10:00:00.000Z', clipSize: mb600);
     await insertTestClip(id: 'clip-3', dateTime: '2026-01-03T10:00:00.000Z', clipSize: mb600);
 
-    final provider = makeProvider(clipStorageLimit: '1GB');
-    await provider.enforceClipStorageLimit();
+    final settings = makeSettings(clipStorageLimit: '1GB');
+    await ClipSaver.enforceClipStorageLimit(settings);
 
     final remaining = await Clip.loadAllClips();
     // Two oldest clips are removed; only the newest survives.
@@ -183,8 +173,8 @@ void main() {
     await insertTestClip(id: 'clip-b', dateTime: '2026-01-02T08:00:00.000Z', clipSize: mb400);
     await insertTestClip(id: 'clip-c', dateTime: '2026-01-03T08:00:00.000Z', clipSize: mb400);
 
-    final provider = makeProvider(clipStorageLimit: '1GB');
-    await provider.enforceClipStorageLimit();
+    final settings = makeSettings(clipStorageLimit: '1GB');
+    await ClipSaver.enforceClipStorageLimit(settings);
 
     final remaining = await Clip.loadAllClips();
     expect(remaining, hasLength(2));
@@ -226,8 +216,8 @@ void main() {
         clipSize: mb600,
       );
 
-      final provider = makeProvider(clipStorageLimit: '1GB');
-      await provider.enforceClipStorageLimit();
+      final settings = makeSettings(clipStorageLimit: '1GB');
+      await ClipSaver.enforceClipStorageLimit(settings);
 
       // clip-old is evicted — both its files must no longer exist on disk.
       expect(videoFile.existsSync(), isFalse,
@@ -262,11 +252,11 @@ void main() {
       clipSize: mb600,
     );
 
-    final provider = makeProvider(clipStorageLimit: '1GB');
+    final settings = makeSettings(clipStorageLimit: '1GB');
 
     // The call must complete normally — missing files must not throw.
     await expectLater(
-      provider.enforceClipStorageLimit(),
+      ClipSaver.enforceClipStorageLimit(settings),
       completes,
     );
 
@@ -302,8 +292,8 @@ void main() {
       clipSize: mb200,
     );
 
-    final provider = makeProvider(clipStorageLimit: '1GB');
-    await provider.enforceClipStorageLimit();
+    final settings = makeSettings(clipStorageLimit: '1GB');
+    await ClipSaver.enforceClipStorageLimit(settings);
 
     // The old large clip must be evicted; the newly saved small clip survives.
     final remaining = await Clip.loadAllClips();
@@ -316,9 +306,9 @@ void main() {
   // ===========================================================================
 
   test('does not throw when the clips table is empty', () async {
-    final provider = makeProvider(clipStorageLimit: '1GB');
+    final settings = makeSettings(clipStorageLimit: '1GB');
 
-    await expectLater(provider.enforceClipStorageLimit(), completes);
+    await expectLater(ClipSaver.enforceClipStorageLimit(settings), completes);
 
     final remaining = await Clip.loadAllClips();
     expect(remaining, isEmpty);


### PR DESCRIPTION
100% test coverage on all provider code except for `recording_provider.dart` since it may change significantly if we switch to HLS

Closes #74 